### PR TITLE
Fetch tailscale server IP

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -3,8 +3,6 @@ provider "cloudflare" {
   api_token = ephemeral.infisical_secret.cloudflare_api_token.value
 }
 
-
-
 data "cloudflare_ip_ranges" "whitelist" {
 
 }
@@ -41,11 +39,30 @@ resource "cloudflare_dns_record" "root" {
   }
 }
 
+# Get the tailscale devices that could be our docker container
+data "tailscale_devices" "container" {
+  name_prefix = var.project_name
+}
+
+# Get the IPv4 address for the matching containers -- there should be just one
+locals {
+  container_devices = {
+    for device in data.tailscale_devices.container.devices :
+    device.name => (
+      try(
+        [for addr in device.addresses : addr if can(regex("^\\d+\\.\\d+\\.\\d+\\.\\d+$", addr))][0],
+        null
+      )
+    )
+  }
+}
+
+# Register a wildcard DNS record for the tailscale container's IP
 resource "cloudflare_dns_record" "webservices" {
   name = "*"
+  for_each = local.container_devices
 
-  count   = length(var.ts_server_ip) > 0 ? 1 : 0
-  content = var.ts_server_ip
+  content = each.value
   proxied = false
   ttl     = 1
   type    = "A"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -38,8 +38,8 @@ provider "hcloud" {
 # Provider for tailscale using provisioning client id
 
 provider "tailscale" {
-  #oauth_client_id     = ephemeral.infisical_secret.tailscale_provider_oauth_client.value
-  # oauth_client_secret = ephemeral.infisical_secret.tailscale_provider_oauth_client_secret.value
-  api_key = ephemeral.infisical_secret.tailscale_api_key.value
+  oauth_client_id     = ephemeral.infisical_secret.tailscale_provider_oauth_client.value
+  oauth_client_secret = ephemeral.infisical_secret.tailscale_provider_oauth_client_secret.value
+  # api_key = ephemeral.infisical_secret.tailscale_api_key.value
   tailnet = nonsensitive(data.infisical_secrets.root_secrets.secrets["TS_TAILNET_NAME"].value)
 }

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -29,6 +29,21 @@ resource "infisical_project_user" "terraform" {
   ]
 }
 
+
+ephemeral "infisical_secret" "tailscale_provider_oauth_client" {
+  name         = "TS_OAUTH_CLIENT_ID"
+  env_slug     = "dev"
+  workspace_id = data.infisical_projects.server.id
+  folder_path  = "/terraform"
+}
+
+ephemeral "infisical_secret" "tailscale_provider_oauth_client_secret" {
+  name         = "TS_OAUTH_CLIENT_SECRET"
+  env_slug     = "dev"
+  workspace_id = data.infisical_projects.server.id
+  folder_path  = "/terraform"
+}
+
 # Generate credentials for infisical login on server for docker
 resource "infisical_identity" "docker_deploy" {
   name = "docker_deploy"

--- a/terraform/tailscale.tf
+++ b/terraform/tailscale.tf
@@ -1,10 +1,10 @@
 # Create an identity for the tailscale docker container and save it to the secrets vault
 
 locals {
-  tailscale_container_tag = "container"
+  tailscale_container_tag = "tag:container"
 }
 resource "tailscale_oauth_client" "docker_identity" {
   description = "Docker OAuth client for ${var.project_name}"
   scopes      = ["devices:core", "auth_keys"]
-  tags        = ["tag:${local.tailscale_container_tag}"]
+  tags        = [local.tailscale_container_tag]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,8 +69,3 @@ variable "infisical_api_url" {
   description = "The infisical api URL. This value will be exported to INFISICAL_API_URL if set"
 }
 
-variable "ts_server_ip" {
-  type        = string
-  default     = ""
-  description = "Server IP assigned by tailscale -- not known until after deploy"
-}


### PR DESCRIPTION
Get the tailscale IP at runtime for cloudflare.  If not known, do nothing.
Switch tailscale terraform provider to use oauth instead of an api key.
