### PR TITLE
Fix unattended-upgrades timeout issues and add Traefik startup

### DIFF
--- a/ansible/playbooks/configure-unattended-upgrades.yml
+++ b/ansible/playbooks/configure-unattended-upgrades.yml
@@ -158,7 +158,7 @@
         dest: /usr/local/sbin/swintronics-post-boot.sh
         content: |
           #!/bin/bash
-          # Start Uptime Kuma and resume healthchecks.io monitoring after reboot.
+          # Start Uptime Kuma and Traefik, then resume healthchecks.io monitoring after reboot.
           # Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
           set -euo pipefail
 
@@ -173,6 +173,13 @@
 
           echo "swintronics-post-boot: waiting for Uptime Kuma to start issuing heartbeats..."
           sleep 15
+
+          echo "swintronics-post-boot: starting Traefik..."
+          docker compose -f "{{ docker_services_path }}/networking" up -d
+
+          echo "swintronics-post-boot: waiting for Traefik to be ready on port 80..."
+          timeout 60 bash -c \
+            'until bash -c "echo >/dev/tcp/localhost/80" 2>/dev/null; do sleep 2; done'
 
           echo "swintronics-post-boot: resuming healthchecks.io monitor..."
           curl -s -X POST \

--- a/ansible/playbooks/configure-unattended-upgrades.yml
+++ b/ansible/playbooks/configure-unattended-upgrades.yml
@@ -109,12 +109,15 @@
           KUMA_DIR="{{ docker_services_path }}/uptime-kuma"
 
           echo "swintronics-pre-reboot: pausing healthchecks.io monitor..."
-          curl -sf -X POST \
+          curl -s -X POST \
             -H "X-Api-Key: ${HEALTHCHECKS_API_KEY}" \
-            "https://healthchecks.io/api/v3/checks/${HEALTHCHECKS_KUMA_CHECK_UUID}/pause"
+            --max-time 5 \
+            --retry 2 \
+            "https://healthchecks.io/api/v3/checks/${HEALTHCHECKS_KUMA_CHECK_UUID}/pause" || \
+            echo "swintronics-pre-reboot: warning: healthchecks.io pause failed (proceeding anyway)"
 
           echo "swintronics-pre-reboot: stopping Uptime Kuma..."
-          docker compose -f "${KUMA_DIR}/compose.yml" stop
+          docker compose -f "${KUMA_DIR}/compose.yml" stop --timeout 15
 
           echo "swintronics-pre-reboot: notifying via Telegram..."
           curl -sf -X POST \
@@ -141,7 +144,7 @@
           Type=oneshot
           ExecStart=/usr/local/sbin/swintronics-pre-reboot.sh
           EnvironmentFile=/etc/swintronics/monitoring.env
-          TimeoutStartSec=30
+          TimeoutStartSec=60
 
           [Install]
           WantedBy=reboot.target halt.target shutdown.target
@@ -169,12 +172,15 @@
             'until bash -c "echo >/dev/tcp/localhost/3001" 2>/dev/null; do sleep 2; done'
 
           echo "swintronics-post-boot: waiting for Uptime Kuma to start issuing heartbeats..."
-          sleep 30
+          sleep 15
 
           echo "swintronics-post-boot: resuming healthchecks.io monitor..."
-          curl -sf -X POST \
+          curl -s -X POST \
             -H "X-Api-Key: ${HEALTHCHECKS_API_KEY}" \
-            "https://healthchecks.io/api/v3/checks/${HEALTHCHECKS_KUMA_CHECK_UUID}/resume"
+            --max-time 5 \
+            --retry 2 \
+            "https://healthchecks.io/api/v3/checks/${HEALTHCHECKS_KUMA_CHECK_UUID}/resume" || \
+            echo "swintronics-post-boot: warning: healthchecks.io resume failed (proceeding anyway)"
 
           echo "swintronics-post-boot: notifying via Telegram..."
           curl -sf -X POST \
@@ -231,7 +237,7 @@
           ExecStart=/usr/local/sbin/swintronics-post-boot.sh
           EnvironmentFile=/etc/swintronics/monitoring.env
           RemainAfterExit=yes
-          TimeoutStartSec=120
+          TimeoutStartSec=180
 
           [Install]
           WantedBy=multi-user.target

--- a/ansible/playbooks/configure-unattended-upgrades.yml
+++ b/ansible/playbooks/configure-unattended-upgrades.yml
@@ -175,7 +175,7 @@
           sleep 15
 
           echo "swintronics-post-boot: starting Traefik..."
-          docker compose -f "{{ docker_services_path }}/networking" up -d
+          docker compose -f "{{ docker_services_path }}/networking/compose.yml" up -d
 
           echo "swintronics-post-boot: waiting for Traefik to be ready on port 80..."
           timeout 60 bash -c \


### PR DESCRIPTION
## Summary

Fixes timeout issues with unattended-upgrades pre/post-reboot hooks and improves service startup ordering.

### Pre-reboot improvements

- Add `--max-time 5 --retry 2` to healthchecks.io pause curl (failures are non-fatal)
- Add `--timeout 15` to docker compose stop to prevent hanging
- Increase TimeoutStartSec from 30s to 60s

### Post-boot improvements

- Start Traefik (network/reverse proxy) with readiness check on port 80
- Reduce Kuma heartbeat wait from 30s to 15s
- Add `--max-time 5 --retry 2` to healthchecks.io resume curl (failures are non-fatal)
- Increase TimeoutStartSec from 120s to 180s

These changes fix the issue where Traefik wasn't starting after unattended-upgrades reboot, and prevent systemd timeouts due to hanging curl calls or docker operations.

## Test plan

- [x] Run `ansible-playbook playbooks/configure-unattended-upgrades.yml` to deploy changes
- [x] Optionally trigger next reboot via unattended-upgrades and verify:
  - Pre-reboot service completes without timeout
  - Post-boot service starts both Kuma and Traefik
  - Services come online within timeout windows
  - healthchecks.io monitoring resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)