### PR TITLE
Deployment docs, upstream tracking, and version bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,4 +296,4 @@ Beszel hub and agent communicate over a Unix socket. The agent requires the hub'
 - Long-term: phone-friendly server management — expose remaining service UIs, document mobile access patterns
 
 ### Upstream Compose File Convention
-Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich.
+Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich, paperless, linkwarden, uptime-kuma, beszel, semaphore. Not tracked: networking/traefik (fully custom), dozzle, dockhand (single-container, written from scratch), stirling-pdf (upstream repo only has build-from-source compose files, no runtime compose).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Repository Is
 
-Infrastructure-as-Code for a self-hosted home server cluster on Hetzner Cloud. It provisions a single Ubuntu server running Docker Compose services, with networking via Tailscale and Traefik, secrets management via Infisical, and monitoring via Uptime Kuma / Prometheus / Grafana.
+Infrastructure-as-Code for a self-hosted server running Docker Compose services, with networking via Tailscale and Traefik, secrets management via Infisical, and monitoring via Uptime Kuma / Beszel. Currently deployed on a Dell XPS13 (`localhost`). Terraform supports optional Hetzner Cloud provisioning (`enable_hetzner = true`) for cloud deployments.
 
 ## Repository Structure
 
@@ -64,6 +64,143 @@ ansible-playbook playbooks/update-service.yml \
 ```
 
 `cluster.sh` reads `backup.env` for healthchecks.io API keys and coordinates startup/shutdown order: networking first/last, Uptime Kuma last up / first down.
+
+## New Deployment Checklist
+
+### Prerequisites (external accounts/services)
+
+- **Cloudflare** — zone for your domain, API token with DNS edit permissions, zone ID
+- **Tailscale** — tailnet with an OAuth client (scopes: `auth_keys`, `devices:core`, `dns:read`, `oauth_keys`); a `container` tag must exist and be assigned to `devices:core`
+- **Infisical** — account + project; a Machine Identity with `admin` role for Terraform, and a separate Machine Identity (`docker_deploy`) created by Terraform for Ansible
+- **healthchecks.io** — account for backup monitoring (optional but referenced in `backup.env`)
+- **Telegram bot** — for Kuma notifications (token + chat ID stored in Infisical under `/server`)
+
+### Required gitignored files
+
+These files must be created manually — they are never committed.
+
+#### `terraform/.auto.tfvars`
+
+```hcl
+infisical_client_id     = ""   # Terraform Machine Identity client ID
+infisical_client_secret = ""   # Terraform Machine Identity client secret
+infisical_project_id    = ""   # Infisical project UUID (from Project Settings → General)
+timezone                = "America/New_York"
+domain_name             = "example.com"
+
+# Hetzner (only needed if enable_hetzner = true):
+# server_types = ["cx22"]
+# volume_size  = 50
+```
+
+#### `ansible/.env`
+
+Copy from `ansible/.env.example` and fill in values. The Machine Identity here is the `docker_deploy` identity created by `terraform apply` — its credentials are output after apply.
+
+```bash
+export INFISICAL_CLIENT_ID=
+export INFISICAL_CLIENT_SECRET=
+export INFISICAL_PROJECT_ID=   # Runtime project ID (different from the Terraform project)
+```
+
+#### `ansible/inventory/host_vars/localhost.yml`
+
+```yaml
+git_user_name: ""
+git_user_email: ""
+
+data_disk_mountpoint: /docker-data   # Must be a btrfs filesystem
+immich_data_location: "{{ data_disk_mountpoint }}/volumes/immich"
+
+tailscale_tag: "server"
+tailscale_authkey_secret: "TS_XPS13_AUTH_KEY"   # Name of secret in Infisical runtime project
+tailscale_subnet: "192.168.X.0/24"
+tailscale_exit_node: true
+
+dns_hostname: "myhostname"   # Used as CNAME target: <dns_hostname>.<domain>
+cert_resolver: "staging"     # Use "staging" until everything works, then "production"
+
+docker_gid: "984"   # Check with: getent group docker | cut -d: -f3
+
+# Set after first Beszel deploy (see Beszel Agent Bootstrap below):
+# beszel_agent_key: ""
+# beszel_agent_token: ""
+```
+
+#### `docker-services/backup.env`
+
+Sourced by `backup.sh` and `cluster.sh`. All `RESTIC_*` vars are passed to `restic` via `sudo -E`.
+
+```bash
+DATA_MOUNTPOINT=/docker-data
+
+# Restic repository (e.g. Backblaze B2, S3, local path)
+RESTIC_REPOSITORY=
+RESTIC_PASSWORD=
+# Add any provider-specific env vars (B2_ACCOUNT_ID, AWS_ACCESS_KEY_ID, etc.)
+
+# healthchecks.io — for pausing/resuming the Kuma heartbeat monitor during backup
+HEARTBEAT_HEALTHCHECK_API_KEY=
+HEARTBEAT_HEALTHCHECK_PAUSE_URL=
+HEARTBEAT_HEALTHCHECK_RESUME_URL=
+
+# Kuma push URLs — created in Kuma UI as push monitors, one per service (optional)
+KUMA_PHOTO_PUSH_URL=
+KUMA_PAPERLESS_PUSH_URL=
+KUMA_LINKWARDEN_PUSH_URL=
+KUMA_KUMA_PUSH_URL=
+```
+
+### Infisical secret structure
+
+Terraform reads from the **Terraform project** (existing, pre-created):
+
+| Path | Key | Description |
+|------|-----|-------------|
+| `/terraform` | `TS_MS_PROVIDER_OAUTH_CLIENT_ID` | Tailscale OAuth client ID |
+| `/terraform` | `TS_MS_PROVIDER_OAUTH_CLIENT_SECRET` | Tailscale OAuth client secret |
+| `/terraform` | `CLOUDFLARE_API_TOKEN` | Cloudflare API token |
+| `/terraform` | `CLOUDFLARE_ZONE_ID` | Cloudflare zone ID |
+| `/terraform` | `HETZNER_TOKEN` | Hetzner API token (only if `enable_hetzner = true`) |
+| `/` | `username` | Server admin username |
+| `/` | `CF_API_EMAIL` | Cloudflare account email |
+| `/` | `CF_DNS_API_TOKEN` | Cloudflare DNS token (copied to runtime project by Terraform) |
+| `/server` | `TELEGRAM_BOT_TOKEN` | Telegram bot token for Kuma notifications |
+| `/server` | `TELEGRAM_CHAT_ID` | Telegram chat ID |
+
+Terraform creates the **Runtime project** and populates it with generated secrets (DB passwords, encryption keys, auth keys). Ansible reads from the Runtime project.
+
+### First deploy sequence
+
+1. Create Infisical Terraform project and populate `/terraform` secrets above
+2. `cd terraform && terraform init && terraform apply` — creates Runtime project, Tailscale node, Cloudflare DNS, generates all service secrets; **run twice** (first apply creates the Runtime project; second populates it)
+3. Set up the server: ensure btrfs data disk is mounted at `data_disk_mountpoint`
+4. `cd ansible && source .env`
+5. `ansible-galaxy collection install -r requirements.yml && pip install infisicalsdk`
+6. `ansible-playbook playbooks/bootstrap.yml` — installs system packages, configures SSH, sudo
+7. `ansible-playbook playbooks/docker.yml` — installs Docker
+8. `ansible-playbook playbooks/tailscale.yml` — joins Tailscale network
+9. `ansible-playbook playbooks/setup-storage.yml` — creates btrfs subvolumes for stateful services
+10. `ansible-playbook playbooks/deploy-versions.yml` — deploys and starts all services
+11. `ansible-playbook playbooks/install-backup.yml` — installs backup cron job
+12. Complete manual setup: Kuma (see below), Beszel (see below), `backup.env` on server
+
+### Restore / Disaster Recovery
+
+The restore procedure is not yet automated. Manual steps:
+
+1. Complete steps 1–11 above on the new server (services start with empty data)
+2. Stop services that own the data to be restored: `docker compose stop <service>`
+3. Initialize the restic repo and restore the snapshot:
+   ```bash
+   sudo -E restic snapshots   # list available snapshots
+   sudo -E restic restore latest --tag <service> --target /
+   ```
+4. Fix ownership if needed (`chown -R <user> <data dir>`)
+5. Restart services: `docker compose start <service>`
+6. Verify data integrity in the UI before re-enabling backup cron
+
+`backup.env` must be present and `RESTIC_*` vars exported before running `restic` commands.
 
 ## Architecture
 
@@ -150,36 +287,12 @@ Beszel hub and agent communicate over a Unix socket. The agent requires the hub'
 
 **Subsequent deploys:** key is already in `localhost.yml`, agent deploys normally.
 
-## Current Work In Progress
+## TODOs
 
-### Context: Migration from Hetzner to XPS13
-
-Migration is complete. All services are running on the Dell XPS13 (`localhost`). The Hetzner server has been decommissioned. `dns_hostname: xps13` in `localhost.yml` is intentional — machine-specific names allow for future multi-node setups.
-
-### Branch: `feature/terraform-restructure`
-
-#### Goal
-Gate all `hcloud_*` resources behind `var.enable_hetzner` (default `false`) so `terraform apply` destroys the Hetzner instance cleanly. Module extraction deferred until a new cloud instance is needed.
-
-#### Done
-- Added `variable "enable_hetzner"` (default `false`) to `variables.tf`
-- `hcloud_server`: `count = min(var.enable_hetzner ? 1 : 0, length(var.server_types))`
-- `hcloud_volume`, `hcloud_volume_attachment`: `count = var.enable_hetzner ? 1 : 0`
-- `hcloud_network`, `hcloud_network_subnet`, `hcloud_server_network`: count gated; refs updated to `[0]` index
-- `hcloud_firewall`: count gated; `server.tf` refs updated to `[0]`
-- `hcloud_ssh_key`: count gated; `server.tf` refs updated to `[0]`
-- `cloudflare_dns_record.root`: `count = var.enable_hetzner ? 1 : 0`
-- `cloudflare_dns_record.ssh` (already count=0): content uses conditional to avoid out-of-bounds ref
-
-#### Next Step
-Run `terraform plan` to confirm plan shows destruction of all hcloud_* resources and `cloudflare_dns_record.root`, then `terraform apply` to decommission. The `webservices` wildcard (Tailscale) and all secrets/auth resources should be unchanged.
-
-#### After Hetzner decommission
-- Update `dns_hostname` in `ansible/inventory/host_vars/localhost.yml` from `xps13` to `swintronics`
 - Update Kuma monitors: add all services, Telegram notifications, healthchecks.io ping
-- Install backup scripts (`server-scripts/`) and cron jobs (`neil.crontab`) on XPS13
 - Consider Renovate bot for automatic Docker image version PRs
 - Add nginx autoindex service to serve `data_disk_mountpoint/logs` over HTTPS (for viewing cron/backup logs from browser/phone)
+- Automate restore procedure
 - Long-term: phone-friendly server management — expose remaining service UIs, document mobile access patterns
 
 ### Upstream Compose File Convention

--- a/ansible/services/beszel/upstream.yml
+++ b/ansible/services/beszel/upstream.yml
@@ -1,0 +1,26 @@
+# Upstream same-system docker-compose.yml from beszel v0.18.7
+# Source: https://github.com/henrygd/beszel/blob/v0.18.7/supplemental/docker/same-system/docker-compose.yml
+# Saved for diffing against compose.yml.j2
+
+services:
+  beszel:
+    image: 'henrygd/beszel'
+    container_name: 'beszel'
+    restart: unless-stopped
+    ports:
+      - '8090:8090'
+    volumes:
+      - ./beszel_data:/beszel_data
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+
+  beszel-agent:
+    image: 'henrygd/beszel-agent'
+    container_name: 'beszel-agent'
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      PORT: 45876
+      KEY: '...'

--- a/ansible/services/linkwarden/upstream.yml
+++ b/ansible/services/linkwarden/upstream.yml
@@ -1,0 +1,31 @@
+# Upstream docker-compose.yml from linkwarden v2.14.0
+# Source: https://github.com/linkwarden/linkwarden/blob/v2.14.0/docker-compose.yml
+# Saved for diffing against compose.yml.j2
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    env_file: .env
+    restart: always
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+  linkwarden:
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
+    restart: always
+    image: ghcr.io/linkwarden/linkwarden:latest
+    ports:
+      - 3000:3000
+    volumes:
+      - ./data:/data/data
+    depends_on:
+      - postgres
+      - meilisearch
+  meilisearch:
+    image: getmeili/meilisearch:v1.12.8
+    restart: always
+    env_file:
+      - .env
+    volumes:
+      - ./meili_data:/meili_data

--- a/ansible/services/paperless/upstream.yml
+++ b/ansible/services/paperless/upstream.yml
@@ -1,0 +1,41 @@
+# Upstream docker-compose.postgres.yml from paperless-ngx v2.20.13
+# Source: https://github.com/paperless-ngx/paperless-ngx/blob/v2.20.13/docker/compose/docker-compose.postgres.yml
+# Saved for diffing against compose.yml.j2
+
+services:
+  broker:
+    image: docker.io/library/redis:8
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+  db:
+    image: docker.io/library/postgres:18
+    restart: unless-stopped
+    volumes:
+      - pgdata:/var/lib/postgresql
+    environment:
+      POSTGRES_DB: paperless
+      POSTGRES_USER: paperless
+      POSTGRES_PASSWORD: paperless
+  webserver:
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+      - broker
+    ports:
+      - "8000:8000"
+    volumes:
+      - data:/usr/src/paperless/data
+      - media:/usr/src/paperless/media
+      - ./export:/usr/src/paperless/export
+      - ./consume:/usr/src/paperless/consume
+    env_file: docker-compose.env
+    environment:
+      PAPERLESS_REDIS: redis://broker:6379
+      PAPERLESS_DBHOST: db
+volumes:
+  data:
+  media:
+  pgdata:
+  redisdata:

--- a/ansible/services/semaphore/upstream.yml
+++ b/ansible/services/semaphore/upstream.yml
@@ -1,0 +1,22 @@
+# Upstream deployment/compose/server/base.yml from semaphore v2.17.28
+# Source: https://github.com/semaphoreui/semaphore/blob/v2.17.28/deployment/compose/server/base.yml
+# Saved for diffing against compose.yml.j2
+
+volumes:
+  server:
+
+services:
+  server:
+    image: docker.io/semaphoreui/semaphore:${SEMAPHORE_VERSION:-latest}
+    restart: always
+    environment:
+      SEMAPHORE_ADMIN_NAME: ${SEMAPHORE_ADMIN_NAME:-Admin}
+      SEMAPHORE_ADMIN: ${SEMAPHORE_ADMIN_USERNAME:-admin}
+      SEMAPHORE_ADMIN_PASSWORD: ${SEMAPHORE_ADMIN_PASSWORD:-p455w0rd}
+      SEMAPHORE_ADMIN_EMAIL: ${SEMAPHORE_ADMIN_EMAIL:-admin@localhost}
+      SEMAPHORE_WEB_ROOT: ${SEMAPHORE_WEB_ROOT:-http://0.0.0.0:3000}
+      SEMAPHORE_ACCESS_KEY_ENCRYPTION: ${SEMAPHORE_ACCESS_KEY_ENCRYPTION:-IlRqgrrO5Gp27MlWakDX1xVrPv4jhoUx+ARY+qGyDxQ=}
+    volumes:
+      - server:/var/lib/semaphore
+    ports:
+      - "3000:3000"

--- a/ansible/services/uptime-kuma/upstream.yml
+++ b/ansible/services/uptime-kuma/upstream.yml
@@ -1,0 +1,12 @@
+# Upstream compose.yaml from uptime-kuma 2.2.1
+# Source: https://github.com/louislam/uptime-kuma/blob/2.2.1/compose.yaml
+# Saved for diffing against compose.yml.j2
+
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    restart: unless-stopped
+    volumes:
+      - ./data:/app/data
+    ports:
+      - "3001:3001"

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -4,13 +4,13 @@
 
 versions:
   # https://github.com/traefik/traefik/releases
-  traefik: "3.6.12"
+  traefik: "3.6.13"
 
   # https://github.com/amir20/dozzle/releases
   dozzle: "v10.2.1"
 
   # https://github.com/immich-app/immich/releases
-  immich: "v2.6.3"
+  immich: "v2.7.4"
 
   # https://github.com/paperless-ngx/paperless-ngx/releases
   paperless: "2.20.13"
@@ -25,10 +25,10 @@ versions:
   linkwarden: "v2.14.0"
 
   # https://github.com/henrygd/beszel/releases
-  beszel: "0.18.6"
+  beszel: "0.18.7"
 
   # https://github.com/semaphoreui/semaphore/releases
   semaphore: "v2.17.28"
 
   # https://github.com/fnsys/dockhand/releases
-  dockhand: "v1.0.22"
+  dockhand: "v1.0.24"


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Full new deployment checklist covering external prerequisites, all required gitignored files with contents (localhost.yml, backup.env, terraform/.auto.tfvars), Infisical secret structure, first deploy sequence, and manual restore procedure; cleaned up stale Hetzner migration notes
- **Upstream tracking**: Added upstream.yml reference files for paperless, linkwarden, uptime-kuma, beszel, semaphore; all diffs verified clean against compose.yml.j2
- **Version bumps**: traefik 3.6.13, immich v2.7.4, beszel 0.18.7, dockhand v1.0.24 (deployed)

## Upstream diff convention
`diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` — update upstream.yml when bumping a service version to catch upstream changes. Tracked: immich, paperless, linkwarden, uptime-kuma, beszel, semaphore.

## Test plan
- [x] Verify deployment docs match reality on a fresh deploy (cactus-cantina)
- [x] On next version bump, fetch and diff new upstream before updating compose template

🤖 Generated with [Claude Code](https://claude.com/claude-code)