### PR TITLE
Update immich to v2.7.5, triple ML healthcheck timeout

### DIFF
--- a/ansible/services/immich-app/compose.yml.j2
+++ b/ansible/services/immich-app/compose.yml.j2
@@ -52,6 +52,8 @@ services:
     healthcheck:
       disable: false
       timeout: 90s
+      interval: 60s
+      start_period: 5m
 
   redis:
     container_name: immich_redis

--- a/ansible/services/immich-app/compose.yml.j2
+++ b/ansible/services/immich-app/compose.yml.j2
@@ -51,19 +51,20 @@ services:
     restart: always
     healthcheck:
       disable: false
+      timeout: 90s
 
   redis:
     container_name: immich_redis
-    image: docker.io/valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
+    image: docker.io/valkey/valkey:9@sha256:3b55fbaa0cd93cf0d9d961f405e4dfcc70efe325e2d84da207a0a8e6d8fde4f9
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:41eacbe83eca995561fe43814fd4891e16e39632806253848efaf04d3c8a8b84
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
     environment:
-      POSTGRES_PASSWORD: ${DB_PASSWORD:?Please set the immich DB_PASSWORD environment variable}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_INITDB_ARGS: '--data-checksums'
@@ -74,6 +75,8 @@ services:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     shm_size: 128mb
     restart: always
+    healthcheck:
+      disable: false
 
 volumes:
   model-cache:

--- a/ansible/services/immich-app/upstream.yml
+++ b/ansible/services/immich-app/upstream.yml
@@ -1,6 +1,15 @@
-# Upstream docker-compose.yml from immich v2.6.1
+# Upstream docker-compose.yml from immich v2.7.5
 # Source: https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
 # Saved for diffing against compose.yml.j2
+
+#
+# WARNING: To install Immich, follow our guide: https://docs.immich.app/install/docker-compose
+#
+# Make sure to use the docker-compose.yml of the current release:
+#
+# https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+#
+# The compose file on main may not be compatible with the latest release.
 
 name: immich
 
@@ -44,7 +53,7 @@ services:
 
   redis:
     container_name: immich_redis
-    image: docker.io/valkey/valkey:9@sha256:3eeb09785cd61ec8e3be35f8804c8892080f3ca21934d628abc24ee4ed1698f6
+    image: docker.io/valkey/valkey:9@sha256:3b55fbaa0cd93cf0d9d961f405e4dfcc70efe325e2d84da207a0a8e6d8fde4f9
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -10,7 +10,7 @@ versions:
   dozzle: "v10.2.1"
 
   # https://github.com/immich-app/immich/releases
-  immich: "v2.7.4"
+  immich: "v2.7.5"
 
   # https://github.com/paperless-ngx/paperless-ngx/releases
   paperless: "2.20.13"


### PR DESCRIPTION
## Summary
- immich v2.7.4 → v2.7.5
- ML healthcheck `timeout: 90s` (3× the 30s default)

## Upstream changes merged from v2.7.5
- valkey 8 → 9 (new image digest)
- postgres new image digest (same vectorchord/pgvectors version)
- database service gains `healthcheck: disable: false`
- `POSTGRES_PASSWORD` required-var hint removed (env is guaranteed by Infisical)

## Test plan
- [ ] Deploy and verify immich starts healthy
- [ ] Confirm ML container healthcheck passes within 90s on cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)