### PR TITLE
Enable hardware watchdog and switch compose restart to always

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ cert_resolver: "staging"     # Use "staging" until everything works, then "produ
 
 docker_gid: "984"   # Check with: getent group docker | cut -d: -f3
 
+hardware_watchdog_module: "iTCO_wdt"   # Intel: iTCO_wdt, AMD: sp5100_tco; omit on unknown hardware
+
 # Set after first Beszel deploy (see Beszel Agent Bootstrap below):
 # beszel_agent_key: ""
 # beszel_agent_token: ""

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -93,6 +93,43 @@
         cmd: awk '$5 >= 3071' /etc/ssh/moduli > /etc/ssh/moduli.tmp && mv /etc/ssh/moduli.tmp /etc/ssh/moduli
       changed_when: false
 
+    - name: Load hardware watchdog module at boot
+      ansible.builtin.copy:
+        content: "{{ hardware_watchdog_module }}\n"
+        dest: "/etc/modules-load.d/{{ hardware_watchdog_module }}.conf"
+        owner: root
+        group: root
+        mode: '0644'
+      when: hardware_watchdog_module is defined
+
+    - name: Load hardware watchdog module now
+      community.general.modprobe:
+        name: "{{ hardware_watchdog_module }}"
+        state: present
+      when: hardware_watchdog_module is defined
+
+    - name: Ensure systemd system.conf.d directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/system.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      when: hardware_watchdog_module is defined
+
+    - name: Configure systemd hardware watchdog
+      ansible.builtin.copy:
+        content: |
+          [Manager]
+          RuntimeWatchdogSec=30s
+          RebootWatchdogSec=2min
+        dest: /etc/systemd/system.conf.d/watchdog.conf
+        owner: root
+        group: root
+        mode: '0644'
+      when: hardware_watchdog_module is defined
+      notify: Reexec systemd
+
     - name: Disable sleep/suspend/hibernate targets
       ansible.builtin.systemd:
         name: "{{ item }}"
@@ -131,3 +168,7 @@
     - name: Restart systemd-logind
       ansible.builtin.debug:
         msg: "logind.conf was changed — reboot when ready for lid/sleep settings to take effect"
+
+    - name: Reexec systemd
+      ansible.builtin.systemd:
+        daemon_reexec: true

--- a/ansible/services/beszel/compose.yml.j2
+++ b/ansible/services/beszel/compose.yml.j2
@@ -8,7 +8,7 @@ services:
   beszel:
     image: henrygd/beszel:{{ versions.beszel }}
     container_name: beszel
-    restart: unless-stopped
+    restart: always
     env_file: .env
     volumes:
       - {{ data_disk_mountpoint }}/volumes/beszel/beszel_data:/beszel_data
@@ -23,7 +23,7 @@ services:
   beszel-agent:
     image: henrygd/beszel-agent:{{ versions.beszel }}
     container_name: beszel-agent
-    restart: unless-stopped
+    restart: always
     network_mode: host
     healthcheck:
       test: ['CMD', '/agent', 'health']

--- a/ansible/services/dockhand/compose.yml.j2
+++ b/ansible/services/dockhand/compose.yml.j2
@@ -8,7 +8,7 @@ services:
   dockhand:
     image: fnsys/dockhand:{{ versions.dockhand }}
     container_name: dockhand
-    restart: unless-stopped
+    restart: always
     env_file: .env
     group_add:
       - "{{ docker_gid }}"

--- a/ansible/services/dozzle/compose.yml.j2
+++ b/ansible/services/dozzle/compose.yml.j2
@@ -14,7 +14,7 @@ services:
     environment:
       DOZZLE_LEVEL: info
       # DOZZLE_FILTER: "dozzle"  # Optional: only show dozzle logs
-    restart: unless-stopped
+    restart: always
     labels:
       traefik.enable: true
       traefik.http.routers.dozzle.entrypoints: websecure

--- a/ansible/services/linkwarden/compose.yml.j2
+++ b/ansible/services/linkwarden/compose.yml.j2
@@ -8,7 +8,7 @@ services:
   postgres:
     image: postgres:16-alpine
     env_file: .env
-    restart: unless-stopped
+    restart: always
     volumes:
       - {{ data_disk_mountpoint }}/volumes/linkwarden/pgdata:/var/lib/postgresql/data
   linkwarden:
@@ -16,7 +16,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
       - TZ=${TZ:-America/New_York}
-    restart: unless-stopped
+    restart: always
     image: ghcr.io/linkwarden/linkwarden:{{ versions.linkwarden }}
     ports:
       - 3000:3000
@@ -32,7 +32,7 @@ services:
       traefik.http.routers.linkwarden.tls.certresolver: ${CERT_RESOLVER}
   meilisearch:
     image: getmeili/meilisearch:v1.12.8
-    restart: unless-stopped
+    restart: always
     env_file:
       - .env
     volumes:

--- a/ansible/services/networking/traefik.yml.j2
+++ b/ansible/services/networking/traefik.yml.j2
@@ -6,7 +6,7 @@ services:
   traefik:
     image: traefik:{{ versions.traefik }}
     container_name: traefik
-    restart: unless-stopped
+    restart: always
     security_opt:
       - no-new-privileges:true
     environment:
@@ -39,7 +39,7 @@ services:
   whoami:
     container_name: simple-service
     image: traefik/whoami
-    restart: unless-stopped
+    restart: always
     labels:
         - "traefik.enable=true"
         - "traefik.http.routers.whoami.rule=Host(`whoami.${SERVER_DOMAIN}`)"

--- a/ansible/services/paperless/compose.yml.j2
+++ b/ansible/services/paperless/compose.yml.j2
@@ -7,12 +7,12 @@ include:
 services:
   broker:
     image: docker.io/library/redis:8
-    restart: unless-stopped
+    restart: always
     volumes:
       - redisdata:/data
   db:
     image: docker.io/library/postgres:18
-    restart: unless-stopped
+    restart: always
     volumes:
       - pgdata:/var/lib/postgresql
     environment:
@@ -21,7 +21,7 @@ services:
       POSTGRES_PASSWORD: paperless
   webserver:
     image: ghcr.io/paperless-ngx/paperless-ngx:{{ versions.paperless }}
-    restart: unless-stopped
+    restart: always
     depends_on:
       - db
       - broker

--- a/ansible/services/semaphore/compose.yml.j2
+++ b/ansible/services/semaphore/compose.yml.j2
@@ -21,7 +21,7 @@ services:
     volumes:
       - {{ data_disk_mountpoint }}/volumes/semaphore/data:/data
       - {{ data_disk_mountpoint }}/volumes/semaphore/tmp:/tmp/semaphore
-    restart: unless-stopped
+    restart: always
     labels:
       traefik.enable: true
       traefik.http.routers.semaphore.entrypoints: websecure

--- a/ansible/services/stirling-pdf/compose.yml.j2
+++ b/ansible/services/stirling-pdf/compose.yml.j2
@@ -16,7 +16,7 @@ services:
       - SECURITY_ENABLE_LOGIN=false
       - LANGS=en_US
       - TZ=${TZ:-America/New_York}
-    restart: unless-stopped
+    restart: always
     labels:
       traefik.enable: true
       traefik.http.routers.stirling-pdf.entrypoints: websecure

--- a/ansible/services/uptime-kuma/compose.yml.j2
+++ b/ansible/services/uptime-kuma/compose.yml.j2
@@ -7,7 +7,7 @@ services:
   uptime-kuma:
     container_name: uptime-kuma
     image: louislam/uptime-kuma:{{ versions.kuma }}
-    restart: unless-stopped
+    restart: always
     volumes:
       - {{ data_disk_mountpoint }}/volumes/uptime-kuma/data:/app/data
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary

- Add optional hardware watchdog setup in `bootstrap.yml`, gated on a new `hardware_watchdog_module` host var (localhost set to `iTCO_wdt`). Systemd pings `/dev/watchdog` every 30s; a kernel hang auto-reboots in ~30s instead of sitting wedged until someone holds the power button.
- Flip every service compose template from `restart: unless-stopped` to `restart: always`. After the Apr 14 03:35 freeze, dockerd's container-state restore skipped traefik on the next boot — `unless-stopped` is unreliable after a hard crash, `always` is more aggressive.

## Context

XPS13 hard-hung at 03:35 EDT on Apr 14. Journal stopped mid-line with no panic, OOM, thermal, or GPU-hang message — a silent kernel lockup. Took ~8h until manual power-cycle. No watchdog was loaded (`iTCO_wdt` was not in modules-load, `RuntimeWatchdogUSec=0`). On the recovery boot, dockerd restored 15 of 16 containers — traefik was missed.

## Test plan

- [x] `ansible-playbook playbooks/bootstrap.yml -e target=localhost` runs clean
- [x] `systemctl show | grep Watchdog` reports `RuntimeWatchdogUSec=30s` / `RebootWatchdogUSec=2min`
- [x] `/dev/watchdog` exists; `lsmod | grep iTCO_wdt` loaded
- [x] Run `deploy-versions.yml` to push new restart policies to running containers
- [x] Confirm `docker inspect <name> --format '{{.HostConfig.RestartPolicy.Name}}'` reports `always` for each service

🤖 Generated with [Claude Code](https://claude.com/claude-code)