### PR TITLE
Add boot-notify; simplify post-boot; move auto-reboot to 03:00

### DIFF
--- a/ansible/playbooks/configure-system-services.yml
+++ b/ansible/playbooks/configure-system-services.yml
@@ -1,13 +1,15 @@
 ---
-# Configure unattended-upgrades for automatic security patch installation.
-# Installs and configures systemd services to gracefully handle reboots:
-# healthchecks.io is paused and Uptime Kuma is stopped before reboot,
-# then both are restored once the server is back online.
+# Configure host-level system services:
+#   - unattended-upgrades for automatic security patches
+#   - pre-reboot hook: pause healthchecks.io, stop Uptime Kuma, notify Telegram
+#   - post-boot hook: wait for Uptime Kuma, resume healthchecks.io, notify Telegram
+#   - boot-notify hook: send a Telegram message on every boot (catches crashes
+#     and watchdog-triggered reboots, not just planned shutdowns)
 #
 # Usage:
-#   ansible-playbook playbooks/configure-unattended-upgrades.yml
+#   ansible-playbook playbooks/configure-system-services.yml
 
-- name: Configure unattended security updates
+- name: Configure host system services
   hosts: "{{ target_host | default('swintronics') }}"
   become: yes
 
@@ -63,7 +65,8 @@
           Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
           Unattended-Upgrade::Remove-Unused-Dependencies "false";
           Unattended-Upgrade::Automatic-Reboot "true";
-          Unattended-Upgrade::Automatic-Reboot-Time "04:00";
+          // Reboot at 03:00, after the 02:00 immich DB dump and before the 04:00 backup cron.
+          Unattended-Upgrade::Automatic-Reboot-Time "03:00";
         mode: '0644'
       notify: restart unattended-upgrades
 
@@ -120,10 +123,13 @@
           docker compose -f "${KUMA_DIR}/compose.yml" stop --timeout 15
 
           echo "swintronics-pre-reboot: notifying via Telegram..."
-          curl -sf -X POST \
+          curl -s -X POST \
+            --max-time 5 \
+            --retry 1 \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d "chat_id=${TELEGRAM_CHAT_ID}" \
-            -d "text=🔄 swintronics: security updates applied, rebooting..."
+            -d "text=🔄 swintronics: security updates applied, rebooting..." || \
+            echo "swintronics-pre-reboot: warning: Telegram notify failed (proceeding anyway)"
 
           echo "swintronics-pre-reboot: done."
         owner: root
@@ -158,28 +164,18 @@
         dest: /usr/local/sbin/swintronics-post-boot.sh
         content: |
           #!/bin/bash
-          # Start Uptime Kuma and Traefik, then resume healthchecks.io monitoring after reboot.
+          # Wait for Uptime Kuma to come back up, then resume healthchecks.io monitoring.
+          # Containers themselves are restarted by dockerd (restart: always); this script
+          # just gates the healthchecks resume on Kuma actually being ready to ping it.
           # Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
           set -euo pipefail
 
-          KUMA_DIR="{{ docker_services_path }}/uptime-kuma"
-
-          echo "swintronics-post-boot: starting Uptime Kuma..."
-          docker compose -f "${KUMA_DIR}/compose.yml" up -d
-
           echo "swintronics-post-boot: waiting for Uptime Kuma to be ready on port 3001..."
-          timeout 60 bash -c \
+          timeout 120 bash -c \
             'until bash -c "echo >/dev/tcp/localhost/3001" 2>/dev/null; do sleep 2; done'
 
           echo "swintronics-post-boot: waiting for Uptime Kuma to start issuing heartbeats..."
           sleep 15
-
-          echo "swintronics-post-boot: starting Traefik..."
-          docker compose -f "{{ docker_services_path }}/networking/compose.yml" up -d
-
-          echo "swintronics-post-boot: waiting for Traefik to be ready on port 80..."
-          timeout 60 bash -c \
-            'until bash -c "echo >/dev/tcp/localhost/80" 2>/dev/null; do sleep 2; done'
 
           echo "swintronics-post-boot: resuming healthchecks.io monitor..."
           curl -s -X POST \
@@ -188,12 +184,6 @@
             --retry 2 \
             "https://healthchecks.io/api/v3/checks/${HEALTHCHECKS_KUMA_CHECK_UUID}/resume" || \
             echo "swintronics-post-boot: warning: healthchecks.io resume failed (proceeding anyway)"
-
-          echo "swintronics-post-boot: notifying via Telegram..."
-          curl -sf -X POST \
-            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -d "chat_id=${TELEGRAM_CHAT_ID}" \
-            -d "text=✅ swintronics: back online after security update reboot."
 
           echo "swintronics-post-boot: done."
         owner: root
@@ -259,6 +249,74 @@
     - name: Enable post-boot service
       service:
         name: swintronics-post-boot
+        enabled: yes
+
+    # ── Boot-notify hook (every boot, including crash/watchdog recovery) ─────
+
+    - name: Deploy boot-notify script
+      copy:
+        dest: /usr/local/sbin/swintronics-boot-notify.sh
+        content: |
+          #!/bin/bash
+          # Send a Telegram message on every boot. Indicates whether the previous
+          # shutdown was clean (planned reboot) or unclean (crash / watchdog / power loss).
+          # Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+          set -euo pipefail
+
+          HOSTNAME=$(hostname -s)
+          KERNEL=$(uname -r)
+          BOOT_TIME=$(uptime -s)
+
+          SHUTDOWN_NOTE=""
+          if journalctl --list-boots --no-pager 2>/dev/null | grep -qE '^[[:space:]]*-1\b'; then
+              if journalctl -b -1 -n 100 --no-pager 2>/dev/null \
+                  | grep -qE "Reached target (Power-Off|Reboot|Halt|System Power Off|Shutdown)"; then
+                  SHUTDOWN_NOTE="✓ prior shutdown was clean"
+              else
+                  SHUTDOWN_NOTE="⚠️ prior shutdown UNCLEAN (crash, watchdog, or power loss)"
+              fi
+          else
+              SHUTDOWN_NOTE="(no prior boot in journal)"
+          fi
+
+          MESSAGE="🟢 ${HOSTNAME} booted
+          Kernel: ${KERNEL}
+          Boot time: ${BOOT_TIME}
+          ${SHUTDOWN_NOTE}"
+
+          curl -s -X POST \
+              --max-time 10 \
+              --retry 2 \
+              "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              -d "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=${MESSAGE}" >/dev/null
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Deploy boot-notify systemd unit
+      copy:
+        dest: /etc/systemd/system/swintronics-boot-notify.service
+        content: |
+          [Unit]
+          Description=Swintronics boot notification (Telegram)
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/swintronics-boot-notify.sh
+          EnvironmentFile=/etc/swintronics/monitoring.env
+          TimeoutStartSec=30
+
+          [Install]
+          WantedBy=multi-user.target
+        mode: '0644'
+      notify: reload systemd
+
+    - name: Enable boot-notify service
+      service:
+        name: swintronics-boot-notify
         enabled: yes
 
   handlers:


### PR DESCRIPTION
## Summary

- Renames \`configure-unattended-upgrades.yml\` → \`configure-system-services.yml\` (broader scope).
- New **boot-notify** oneshot fires on every boot — planned, crash, or watchdog — sending hostname/kernel/boot-time and a clean/unclean shutdown indicator (parsed from \`journalctl -b -1\`) to Telegram. Reuses the existing \`/etc/swintronics/monitoring.env\` credentials file.
- Auto-reboot moved 04:00 → **03:00** to clear the 04:00 backup cron (after the 02:00 immich DB dump).
- Post-boot script no longer runs \`docker compose up -d\` for Kuma/Traefik (now redundant: all services use \`restart: always\`); just waits for Kuma readiness and resumes healthchecks.io.
- Post-boot Telegram dropped (redundant with boot-notify); the existing \`OnFailure=swintronics-post-boot-failed.service\` still alerts on restoration failure.
- Pre-reboot Telegram gets \`--max-time 5 --retry 1\` so a slow Telegram API can't block shutdown.

## Test plan

- [x] \`ansible-playbook playbooks/configure-system-services.yml --check\` succeeds
- [x] After apply: \`systemctl is-enabled swintronics-boot-notify swintronics-pre-reboot swintronics-post-boot\` — all enabled
- [x] \`systemctl start swintronics-boot-notify\` triggers a Telegram message
- [x] Reboot the host; verify pre-reboot Telegram, post-boot healthchecks resume, and boot-notify Telegram all fire correctly
- [x] Inspect \`/etc/apt/apt.conf.d/50swintronics-unattended-upgrades\` — reboot time is 03:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)