### PR TITLE
Add configure-system-services playbook (unattended-upgrades + reboot hooks + boot-notify)

### DIFF
--- a/ansible/playbooks/configure-system-services.yml
+++ b/ansible/playbooks/configure-system-services.yml
@@ -270,7 +270,7 @@
           SHUTDOWN_NOTE=""
           if journalctl --list-boots --no-pager 2>/dev/null | grep -qE '^[[:space:]]*-1\b'; then
               if journalctl -b -1 -n 100 --no-pager 2>/dev/null \
-                  | grep -qE "Reached target (Power-Off|Reboot|Halt|System Power Off|Shutdown)"; then
+                  | grep -qiE "Reached target (power-off|reboot|halt|shutdown)\\.target"; then
                   SHUTDOWN_NOTE="✓ prior shutdown was clean"
               else
                   SHUTDOWN_NOTE="⚠️ prior shutdown UNCLEAN (crash, watchdog, or power loss)"


### PR DESCRIPTION
## Summary

- Renames `configure-upgrades.yml` → `configure-system-services.yml` and expands it significantly
- Configures unattended-upgrades with automatic reboot at 03:00 (between the 02:00 Immich DB dump and 04:00 backup cron)
- Adds `swintronics-pre-reboot` systemd service: pauses healthchecks.io and stops Uptime Kuma before any reboot
- Adds `swintronics-post-boot` systemd service: waits for Kuma to come back up, then resumes healthchecks.io; sends Telegram alert on failure
- Adds `swintronics-boot-notify` systemd service: sends a Telegram message on every boot, distinguishing clean shutdowns from crashes/watchdog resets
- Monitoring credentials (Telegram, healthchecks.io) deployed to `/etc/swintronics/monitoring.env` (root:root, 0600) from Infisical

## Test plan

- [x] Run `ansible-playbook playbooks/configure-system-services.yml --check` (dry run)
- [x] Run the playbook and verify all three systemd units are enabled
- [x] Confirm Telegram boot notification arrives after next reboot
- [x] Confirm healthchecks.io monitor resumes after reboot (no false-positive alert)
- [x] Trigger a planned reboot via unattended-upgrades or manually; verify "prior shutdown was clean" in Telegram message

🤖 Generated with [Claude Code](https://claude.com/claude-code)