### PR TITLE
Deploy Gatus alongside Uptime Kuma

### DIFF
--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -67,6 +67,13 @@
           - { src: .env.j2,         dest: .env,               secret: true }
           - { src: backup-execute,  dest: backup-execute,     executable: true }
           - { src: backup-remote,   dest: backup-remote,      executable: true }
+      gatus:
+        dir: gatus
+        dns_names: [gatus]
+        files:
+          - { src: compose.yml.j2,  dest: compose.yml }
+          - { src: config.yaml.j2,  dest: config.yaml }
+          - { src: .env.j2,         dest: .env,               secret: true }
       stirling_pdf:
         dir: stirling-pdf
         dns_names: [stirling-pdf]

--- a/ansible/playbooks/setup-storage.yml
+++ b/ansible/playbooks/setup-storage.yml
@@ -30,6 +30,7 @@
       immich:      { dir: immich,       stateful: true, subvol_path: "immich/library" }
       paperless:   { dir: paperless,    stateful: true  }
       kuma:        { dir: uptime-kuma,  stateful: true  }
+      gatus:       { dir: gatus,        stateful: true  }
       stirling_pdf: { dir: stirling-pdf, stateful: false }
       linkwarden:  { dir: linkwarden,   stateful: true  }
       beszel:      { dir: beszel,       stateful: true  }

--- a/ansible/services/gatus/.env.j2
+++ b/ansible/services/gatus/.env.j2
@@ -1,0 +1,5 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+CERT_RESOLVER={{ cert_resolver }}
+GATUS_TELEGRAM_BOT_TOKEN={{ infisical_secrets.secrets.SERVER_TELEGRAM_BOT_TOKEN }}
+GATUS_TELEGRAM_CHAT_ID={{ infisical_secrets.secrets.SERVER_TELEGRAM_CHAT_ID }}
+GATUS_HEALTHCHECKS_PING_URL=https://hc-ping.com/{{ infisical_secrets.secrets.HEALTHCHECKS_KUMA_CHECK_UUID }}

--- a/ansible/services/gatus/compose.yml.j2
+++ b/ansible/services/gatus/compose.yml.j2
@@ -1,0 +1,22 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+
+include:
+  - ../networks.yml
+
+services:
+  gatus:
+    container_name: gatus
+    image: twinproduction/gatus:{{ versions.gatus }}
+    restart: always
+    env_file: .env
+    volumes:
+      - {{ data_disk_mountpoint }}/volumes/gatus:/data
+      - ./config.yaml:/config/config.yaml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    labels:
+      traefik.enable: true
+      traefik.http.routers.gatus.entrypoints: websecure
+      traefik.http.routers.gatus.rule: Host(`{{ _service_config.gatus.dns_names[0] }}.{{ server_domain }}`)
+      traefik.http.routers.gatus.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.services.gatus.loadbalancer.server.port: 8080

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -1,0 +1,77 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+
+storage:
+  type: sqlite
+  path: /data/data.db
+
+alerting:
+  telegram:
+    token: ${GATUS_TELEGRAM_BOT_TOKEN}
+    id: ${GATUS_TELEGRAM_CHAT_ID}
+
+endpoints:
+  # ── Services (5m, 3 retries) ──────────────────────────────────────────────
+  - name: Immich
+    group: Services
+    url: https://photos.{{ server_domain }}/api/server/ping
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Paperless
+    group: Services
+    url: https://paperless.{{ server_domain }}/accounts/login/
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Linkwarden
+    group: Services
+    url: https://linkwarden.{{ server_domain }}/api/v1/logins
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Stirling-PDF
+    group: Services
+    url: https://stirling-pdf.{{ server_domain }}/api/v1/info/status
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  # ── System Monitoring (5m, 3 retries) ─────────────────────────────────────
+  - name: Traefik
+    group: System Monitoring
+    url: https://traefik.{{ server_domain }}/api/version
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Dockhand
+    group: System Monitoring
+    url: https://dockhand.{{ server_domain }}/api/health
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Beszel
+    group: System Monitoring
+    url: https://beszel.{{ server_domain }}/api/health
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Beszel agent
+    group: System Monitoring
+    url: tcp://host.docker.internal:45876
+    interval: 5m
+    conditions: ["[CONNECTED] == true"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
+  # ── Healthchecks.io heartbeat (60s, 3 retries) ────────────────────────────
+  - name: Healthchecks.io heartbeat
+    group: System Monitoring
+    url: ${GATUS_HEALTHCHECKS_PING_URL}
+    interval: 60s
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -18,6 +18,9 @@ versions:
   # https://github.com/louislam/uptime-kuma/releases
   kuma: "2.2.1"
 
+  # https://github.com/TwiN/gatus/releases
+  gatus: "v5.35.0"
+
   # https://github.com/Stirling-Tools/Stirling-PDF/releases
   stirling_pdf: "2.7.3"
 


### PR DESCRIPTION
## Summary

Deploy Gatus 5.35.0 as a side-by-side monitoring alternative to Uptime Kuma. The eventual goal is to replace Kuma with Gatus since Gatus is YAML-config-driven (fits IaC better) while Kuma is UI-driven. This change is observation-only — Kuma keeps running unchanged.

- New service at `https://gatus.swintronics.com`
- Telegram alerts via existing `SERVER_TELEGRAM_BOT_TOKEN` / `SERVER_TELEGRAM_CHAT_ID` from Infisical
- Healthchecks.io heartbeat reuses existing `HEALTHCHECKS_KUMA_CHECK_UUID`
- SQLite storage at `/docker-data/volumes/gatus`

## Monitors

Mirrors the existing Kuma layout:

- **Services** (5m, 3 retries): Immich, Paperless, Linkwarden, Stirling-PDF
- **System Monitoring** (5m, 3 retries): Traefik (`/api/version`), Dockhand, Beszel hub, Beszel agent (TCP/45876 via `host.docker.internal`)
- **System Monitoring** (60s, 3 retries): Healthchecks.io heartbeat

## Tested on

- XPS13 (swintronics cluster) — all 9 endpoints reporting `success=true` on first run, dashboard reachable

## Not included (future work)

- **Backup external-endpoints** — Kuma still receives backup push notifications; cutting over the backup scripts to push to Gatus is a separate change
- **Decommission Kuma** — once we're confident Gatus is covering everything, remove Kuma service + monitors + backup scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)