### PR TITLE
Bump versions and adopt floating tags

### DIFF
--- a/ansible/services/linkwarden/upstream.yml
+++ b/ansible/services/linkwarden/upstream.yml
@@ -1,5 +1,5 @@
-# Upstream docker-compose.yml from linkwarden v2.14.0
-# Source: https://github.com/linkwarden/linkwarden/blob/v2.14.0/docker-compose.yml
+# Upstream docker-compose.yml from linkwarden v2.14.1
+# Source: https://github.com/linkwarden/linkwarden/blob/v2.14.1/docker-compose.yml
 # Saved for diffing against compose.yml.j2
 
 services:
@@ -14,7 +14,8 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
     restart: always
-    image: ghcr.io/linkwarden/linkwarden:latest
+    # build: . # uncomment to build from source
+    image: ghcr.io/linkwarden/linkwarden:latest # comment to build from source
     ports:
       - 3000:3000
     volumes:

--- a/ansible/services/paperless/upstream.yml
+++ b/ansible/services/paperless/upstream.yml
@@ -1,7 +1,33 @@
-# Upstream docker-compose.postgres.yml from paperless-ngx v2.20.13
-# Source: https://github.com/paperless-ngx/paperless-ngx/blob/v2.20.13/docker/compose/docker-compose.postgres.yml
+# Upstream docker-compose.postgres.yml from paperless-ngx v2.20.15
+# Source: https://github.com/paperless-ngx/paperless-ngx/blob/v2.20.15/docker/compose/docker-compose.postgres.yml
 # Saved for diffing against compose.yml.j2
 
+# Docker Compose file for running paperless from the Docker Hub.
+# This file contains everything paperless needs to run.
+# Paperless supports amd64, arm and arm64 hardware.
+#
+# All compose files of paperless configure paperless in the following way:
+#
+# - Paperless is (re)started on system boot, if it was running before shutdown.
+# - Docker volumes for storing data are managed by Docker.
+# - Folders for importing and exporting files are created in the same directory
+#   as this file and mounted to the correct folders inside the container.
+# - Paperless listens on port 8000.
+#
+# In addition to that, this Docker Compose file adds the following optional
+# configurations:
+#
+# - Instead of SQLite (default), PostgreSQL is used as the database server.
+#
+# To install and update paperless with this file, do the following:
+#
+# - Copy this file as 'docker-compose.yml' and the files 'docker-compose.env'
+#   and '.env' into a folder.
+# - Run 'docker compose pull'.
+# - Run 'docker compose up -d'.
+#
+# For more extensive installation and update instructions, refer to the
+# documentation.
 services:
   broker:
     image: docker.io/library/redis:8

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -1,37 +1,41 @@
 ---
 # Service versions — edit these and run deploy-versions.yml to update.
 # Ansible will only restart services whose compose file actually changes.
+#
+# Tag strategy:
+#   - Floating tags (e.g. "v3.6", "2.20", "v5") catch patches automatically.
+#   - Pinned tags (e.g. "v2.7.5") are used for fast-moving or pre-1.0 software
+#     where minor/patch upgrades have a real chance of breaking things.
+#   - Tag prefix conventions vary across registries — match what each image
+#     publishes (e.g. traefik uses "v3.6", paperless uses "2.20", beszel "0.18.7").
 
 versions:
-  # https://github.com/traefik/traefik/releases
-  traefik: "3.6.13"
+  # https://github.com/traefik/traefik/releases — floating minor
+  traefik: "v3.6"
 
-  # https://github.com/amir20/dozzle/releases
-  dozzle: "v10.2.1"
-
-  # https://github.com/immich-app/immich/releases
+  # https://github.com/immich-app/immich/releases — pinned (rapid breaking changes)
   immich: "v2.7.5"
 
-  # https://github.com/paperless-ngx/paperless-ngx/releases
-  paperless: "2.20.13"
+  # https://github.com/paperless-ngx/paperless-ngx/releases — floating minor
+  paperless: "2.20"
 
-  # https://github.com/louislam/uptime-kuma/releases
+  # https://github.com/louislam/uptime-kuma/releases — pinned (decommissioning)
   kuma: "2.2.1"
 
-  # https://github.com/TwiN/gatus/releases
-  gatus: "v5.35.0"
+  # https://github.com/TwiN/gatus/releases — floating major
+  gatus: "v5"
 
-  # https://github.com/Stirling-Tools/Stirling-PDF/releases
-  stirling_pdf: "2.7.3"
+  # https://github.com/Stirling-Tools/Stirling-PDF/releases — pinned
+  stirling_pdf: "2.10.0"
 
-  # https://github.com/linkwarden/linkwarden/releases
-  linkwarden: "v2.14.0"
+  # https://github.com/linkwarden/linkwarden/releases — pinned
+  linkwarden: "v2.14.1"
 
-  # https://github.com/henrygd/beszel/releases
+  # https://github.com/henrygd/beszel/releases — pinned (pre-1.0)
   beszel: "0.18.7"
 
-  # https://github.com/fnsys/dockhand/releases
-  dockhand: "v1.0.24"
+  # https://hub.docker.com/r/fnsys/dockhand/tags — pinned (small project)
+  dockhand: "v1.0.27"
 
-  # https://hub.docker.com/r/willfarrell/autoheal — restarts containers labeled autoheal=true when unhealthy
+  # https://hub.docker.com/r/willfarrell/autoheal — pinned (rarely updated)
   autoheal: "1.2.0"


### PR DESCRIPTION
## Summary

Adopt a per-service tag strategy: floating tags for stable upstreams, pinned tags for fast-moving or pre-1.0 software. Bump everything that had a newer version available.

## Tag strategy changes

| Service | Old | New | Rationale |
|---------|-----|-----|-----------|
| traefik | `3.6.13` | `v3.6` | Floating minor — Traefik patches are reliable |
| paperless | `2.20.13` | `2.20` | Floating minor — paperless-ngx doesn't publish a `2` major tag |
| gatus | `v5.35.0` | `v5` | Floating major — config-driven, low surface area |

## Version pin bumps

| Service | Old | New |
|---------|-----|-----|
| stirling-pdf | `2.7.3` | `2.10.0` |
| linkwarden | `v2.14.0` | `v2.14.1` |
| dockhand | `v1.0.24` | `v1.0.27` |

## Pinned, no version change

immich (`v2.7.5`), kuma (`2.2.1`), beszel (`0.18.7`), autoheal (`1.2.0`) — all already at latest.

## Other notes

- Removed unused `dozzle` entry — service is no longer deployed
- Refreshed `upstream.yml` snapshots for paperless and linkwarden to the new tagged versions; no functional differences from upstream

## Tested on

- XPS13 (swintronics cluster) — all six services pulled new images and restarted cleanly; gatus continues to report `success=true` for all monitored endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)