### PR TITLE
Add Claude Code skills and hooks for ansible workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // .tool_response.filePath // \"\"')\ncase \"$file\" in\n  */ansible/*.yml|*/ansible/*.yaml) ;;\n  *) exit 0 ;;\nesac\nout=$(ansible-lint --profile=min \"$file\" 2>&1)\nif [ $? -ne 0 ]; then\n  printf \"ansible-lint (--profile=min) reported issues in %s:\\n%s\\n\" \"$file\" \"$out\" >&2\n  exit 2\nfi\nexit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/deploy-and-verify/SKILL.md
+++ b/.claude/skills/deploy-and-verify/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: deploy-and-verify
+description: Deploy Ansible changes and verify they actually landed on the target before reporting success. Use after editing ansible/versions.yml or any ansible/services/*. Catches the "edited playbook but never ran it" and "ran playbook but container crashed" failure modes. Optional arg: a single service name to scope deploy to update-service.yml.
+---
+
+# Deploy and Verify
+
+Run the Ansible deploy, then prove the change actually landed on the target host. Do **not** report success based on Ansible's exit code alone — past incidents (Telegram-on-reboot, #56) were caused by undeployed code.
+
+## Workflow
+
+### 1. Identify what's about to change
+
+```bash
+cd /home/neil/git/swintronics
+git status ansible/ ansible/versions.yml
+git diff --stat ansible/
+```
+
+Note the touched paths under `ansible/services/<service>/` and any version bumps in `versions.yml`. These are the services to verify in step 3.
+
+### 2. Run the deploy
+
+If the user invoked `/deploy-and-verify <service>` with a service name:
+
+```bash
+cd /home/neil/git/swintronics/ansible
+source .env
+# Look up the new_version from versions.yml if needed:
+ansible-playbook playbooks/update-service.yml -e service_name=<service> -e new_version=<version>
+```
+
+Otherwise (no arg → multi-service deploy):
+
+```bash
+cd /home/neil/git/swintronics/ansible
+source .env
+ansible-playbook playbooks/deploy-versions.yml
+```
+
+If Ansible exits non-zero, stop here and report the failure with the relevant task output. Do **not** continue to verification.
+
+If Ansible exits zero but its summary says `changed=0` for every host AND the git diff in step 1 was non-empty, that's a red flag — Ansible thinks nothing changed but you have local edits. Surface this and ask the user.
+
+### 3. Verify on the target
+
+The target host is read from the inventory — for the XPS13 it's `localhost` (control node *is* the server). For remote targets, prefix the verification commands with `ssh <tailscale-host>` or use `ansible <host> -m shell -a "..."`.
+
+For **each** service identified in step 1, check three things:
+
+**(a) Rendered compose file landed.** The file mtime on the server should be within the last few minutes:
+
+```bash
+stat -c '%y %n' /home/neil/swintronics/docker-services/<service-dir>/compose.yml
+```
+
+Map service → directory using the table in `CLAUDE.md` (e.g. `immich` → `immich-app`, `kuma` → `uptime-kuma`).
+
+**(b) Container is running.** `State` must be `running`, not `exited`/`restarting`/`created`:
+
+```bash
+cd /home/neil/swintronics/docker-services/<service-dir>
+docker compose ps --format json | jq '.[] | {Service, State, Status}'
+```
+
+If any container is in `restarting`, wait 30s and re-check — if still restarting, pull `docker compose logs --tail=50 <service>` and surface the failure.
+
+**(c) For version bumps: running image tag matches `versions.yml`.**
+
+```bash
+docker compose ps --format json | jq -r '.[] | "\(.Service) \(.Image)"'
+```
+
+Compare each `<service> <image:tag>` line against the value in `ansible/versions.yml`. Mismatch means the deploy ran but the container didn't restart with the new image — flag it.
+
+### 4. Report
+
+One line per check, pass/fail. If everything passes:
+
+```
+deploy-and-verify: <service>
+  ✓ ansible playbook completed
+  ✓ rendered compose file landed (mtime <Xs ago>)
+  ✓ container running (Up <Xs>)
+  ✓ image tag matches versions.yml
+```
+
+If anything fails, lead with the failure and the next debugging step (usually `docker compose logs` or re-running the playbook with `-vv`).
+
+## What this skill does *not* cover
+
+- Service-specific behavior checks (curl health endpoints, trigger a test notification). Those belong in Gatus/Kuma, not this skill.
+- Rollback. If a deploy lands but the container crashes, the operator decides whether to revert `versions.yml` or fix forward.
+- Multi-host fan-out. For now, assumes a single target host per invocation.

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: triage-issue
+description: Take a GitHub issue number and drive it through branch → changes → PR. Use when the user says `/triage-issue <num>`. Encodes the issue-to-PR discipline so the work is auditable: feature branch, scoped edits, PR linking back to the issue. Does NOT deploy — `/deploy-and-verify` is the manual deploy step after merge.
+---
+
+# Triage Issue
+
+Drive a GitHub issue from triage to open PR. The user supplies an issue number; you do the rest.
+
+## Preflight
+
+1. Confirm `gh auth status` shows logged in.
+2. Confirm clean working tree: `git status --porcelain` must be empty. If not, stop and ask the user — don't stash silently.
+3. Confirm you're on `main` and up-to-date: `git fetch origin && git status -sb`. If behind, `git pull --ff-only`.
+
+If any check fails, surface the exact issue and ask the user how to proceed. Don't reset, stash, or check out other branches without permission.
+
+## Fetch the issue
+
+```bash
+gh issue view <num> --json number,title,body,labels,state
+```
+
+If `state` is not `OPEN`, stop and ask the user — they may have linked the wrong issue.
+
+Read the body carefully. If it's vague or missing acceptance criteria, ask the user one targeted question before proceeding. A clearer scope at the start saves a wasted branch.
+
+## Create the branch
+
+Slug the title (lowercase, dashes, alphanumeric only, max 40 chars):
+
+```bash
+slug=$(echo "<title>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+git checkout -b "issue-<num>-${slug}"
+```
+
+The pre-commit hook in `~/.claude/settings.json` will reject commits on `main` anyway, but creating the branch up front avoids any chance of stray edits landing wrong.
+
+## Make the changes
+
+Use the repo context: read `CLAUDE.md` for architecture, look at existing patterns under `ansible/services/<similar-service>/` or `terraform/` before writing new code. The repo conventions matter — prefer editing existing playbooks/templates over creating new ones.
+
+Common shapes for this repo:
+
+- **Version bump for a service** → edit `ansible/versions.yml`; if upstream compose changed, also diff `ansible/services/<svc>/upstream.yml` and update `compose.yml.j2` (see `feedback_upstream_diffs` memory).
+- **New monitor / config tweak** → likely edits under `ansible/services/gatus/` (for Gatus endpoints) or per-service compose.
+- **Terraform change** → edits under `terraform/`, run `terraform plan` locally before committing.
+- **Backup or cron logic** → likely under `server-scripts/` plus rendering via `ansible/services/backup/backup.env.j2`.
+
+Stay scoped to what the issue asks for. Don't refactor surrounding code or fix unrelated style issues — those belong in separate issues/PRs.
+
+## Verify locally (skip what doesn't apply)
+
+- Terraform changes: `cd terraform && terraform plan` (no apply).
+- Ansible changes: `cd ansible && ansible-playbook playbooks/<relevant>.yml --check --diff` if you can reach the target. If not, at minimum run `ansible-playbook --syntax-check`.
+- Compose template changes: `ansible-playbook playbooks/deploy-versions.yml --check --diff` to see what would render.
+
+Don't promise the change works if you can't verify — call it out in the PR body.
+
+## Commit and push
+
+Show the diff to the user and ask for confirmation before committing. Then:
+
+```bash
+git add <specific-files>           # never `git add -A`
+git commit -m "<short subject>
+
+<body referencing the issue and the approach>
+
+Closes #<num>
+"
+git push -u origin "issue-<num>-${slug}"
+```
+
+The pre-commit hook will block any attempt to commit on main or to bypass GPG signing — don't try to work around it. If signing fails, surface the error to the user instead of disabling signing.
+
+## Open the PR
+
+```bash
+gh pr create \
+  --title "<short, under 70 chars>" \
+  --body "$(cat <<EOF
+## Summary
+<1–3 bullets on what changed>
+
+## Why
+<link to issue context; the issue's "why" is the PR's "why">
+
+## Test plan
+- [ ] <how to verify; usually \`/deploy-and-verify <service>\` after merge>
+
+Closes #<num>
+EOF
+)"
+```
+
+Return the PR URL to the user.
+
+## What this skill does *not* do
+
+- Deploy. `/deploy-and-verify` is the post-merge step the user runs locally.
+- Auto-merge. The PR sits open for human review.
+- Skip review when the issue is "obviously simple." Always show the diff and confirm before committing.
+- Touch unrelated code. If you spot adjacent issues, mention them in the PR body or as a follow-up issue, don't fold them in.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,15 +308,17 @@ All runtime secrets are stored in **Infisical** (project: "Swintronics Runtime",
 
 | service_name   | directory      | template                            |
 |----------------|----------------|-------------------------------------|
-| immich         | immich-app     | services/immich-app/compose.yml.j2  |
-| paperless      | paperless      | services/paperless/compose.yml.j2   |
-| kuma           | uptime-kuma    | services/uptime-kuma/compose.yml.j2 |
-| stirling-pdf   | stirling-pdf   | services/stirling-pdf/compose.yml.j2|
-| traefik        | networking     | services/networking/traefik.yml.j2  |
+| immich         | immich-app     | services/immich-app/compose.yml.j2    |
+| paperless      | paperless      | services/paperless/compose.yml.j2     |
+| stirling-pdf   | stirling-pdf   | services/stirling-pdf/compose.yml.j2  |
+| traefik        | networking     | services/networking/traefik.yml.j2    |
 | autoheal       | autoheal       | services/autoheal/compose.yml.j2      |
 | homeassistant  | homeassistant  | services/homeassistant/compose.yml.j2 |
 | zigbee2mqtt    | zigbee2mqtt    | services/zigbee2mqtt/compose.yml.j2   |
 | mosquitto      | mosquitto      | services/mosquitto/compose.yml.j2     |
+| beszel         | beszel         | services/beszel/compose.yml.j2        |
+| dockhand       | dockhand       | services/dockhand/compose.yml.j2      |
+| gatus          | gatus          | services/gatus/compose.yml.j2         |
 
 ### Networking
 


### PR DESCRIPTION
## Summary

From the `/insights` review of recent sessions — four pieces of tooling to encode the issue-to-PR discipline and catch the "edited playbook but never deployed" class of bug.

- **`.claude/skills/deploy-and-verify/`** — post-deploy verification skill (`/deploy-and-verify <service>`). After Ansible reports success, confirm rendered compose file mtime moved, container is `running`, and image tag matches `versions.yml`. Catches the Telegram-on-reboot class of bug surfaced in PR #56.
- **`.claude/skills/triage-issue/`** — `/triage-issue <num>` drives a GitHub issue from branch creation through PR open. Preflight (clean tree, on main), slug-based branch naming, scoped edits, links PR to issue via `Closes #N`.
- **`.claude/settings.json`** — PostToolUse hook running `ansible-lint --profile=min` on edits to `ansible/**.yml`. Profile=min skips ~30 pre-existing yaml[commas]/yaml[truthy] warnings and only fires on real failures (parse errors, unknown modules).
- **`CLAUDE.md`** — Service Name Mapping refresh: drop `kuma` (gone in #61), add `beszel`, `dockhand`, `gatus`. `backup` left out (renders `backup.env.j2`, not a compose template).

A companion git-commit-guard hook lives in the global `~/.claude/settings.json` (not committed here) to block direct main-branch edits and GPG-signing bypass attempts.

## Test plan

- [x] Open a fresh Claude Code session in this dir; verify `/deploy-and-verify` and `/triage-issue` appear in the skills list
- [x] Run `/hooks` and confirm the PostToolUse ansible-lint hook is listed
- [ ] Edit a clean ansible playbook (e.g. `ansible/playbooks/docker.yml`); hook should stay silent
- [ ] Deliberately break a playbook (e.g. missing colon in `apps.yml`); hook should surface the failure
- [ ] Use `/deploy-and-verify` on a service after a real ansible change; confirm the three landing checks pass
- [ ] Use `/triage-issue` against a real low-stakes issue to exercise the branch-and-PR flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)