### PR TITLE
gatus: remove maintenance window, add explicit enabled flag

### DIFF
--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -7,11 +7,6 @@ storage:
   type: sqlite
   path: /data/data.db
 
-maintenance:
-  start: "03:55"
-  duration: 20m
-  timezone: "America/New_York"
-
 alerting:
   telegram:
     token: ${GATUS_TELEGRAM_BOT_TOKEN}
@@ -20,6 +15,7 @@ alerting:
 endpoints:
   # ── Services (5m, 3 retries) ──────────────────────────────────────────────
   - name: Immich
+    enabled: true
     group: Services
     url: https://photos.{{ server_domain }}/api/server/ping
     interval: 5m
@@ -27,6 +23,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Paperless
+    enabled: true
     group: Services
     url: https://paperless.{{ server_domain }}/accounts/login/
     interval: 5m
@@ -34,6 +31,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Stirling-PDF
+    enabled: true
     group: Services
     url: https://stirling-pdf.{{ server_domain }}/api/v1/info/status
     interval: 5m
@@ -41,6 +39,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Home Assistant
+    enabled: true
     group: Services
     url: https://ha.{{ server_domain }}/
     interval: 5m
@@ -48,6 +47,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Zigbee2MQTT
+    enabled: true
     group: Services
     url: https://z2m.{{ server_domain }}/
     interval: 5m
@@ -56,6 +56,7 @@ endpoints:
 
   # ── System Monitoring (5m, 3 retries) ─────────────────────────────────────
   - name: Traefik
+    enabled: true
     group: System Monitoring
     url: https://traefik.{{ server_domain }}/api/version
     interval: 5m
@@ -63,6 +64,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Dockhand
+    enabled: true
     group: System Monitoring
     url: https://dockhand.{{ server_domain }}/api/health
     interval: 5m
@@ -70,6 +72,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Beszel
+    enabled: true
     group: System Monitoring
     url: https://beszel.{{ server_domain }}/api/health
     interval: 5m
@@ -77,6 +80,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Beszel agent
+    enabled: true
     group: System Monitoring
     url: tcp://host.docker.internal:45876
     interval: 5m
@@ -85,6 +89,7 @@ endpoints:
 
   # ── Healthchecks.io heartbeat (60s, 3 retries) ────────────────────────────
   - name: Healthchecks.io heartbeat
+    enabled: true
     group: System Monitoring
     url: ${GATUS_HEALTHCHECKS_PING_URL}
     interval: 60s
@@ -94,6 +99,7 @@ endpoints:
 external-endpoints:
   # ── Backups (push from backup-remote scripts, alert if no ping in 25h) ─────
   - name: Immich
+    enabled: true
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:
@@ -101,6 +107,7 @@ external-endpoints:
     alerts: [{type: telegram, failure-threshold: 1, success-threshold: 1, send-on-resolved: true}]
 
   - name: Paperless
+    enabled: true
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:
@@ -108,6 +115,7 @@ external-endpoints:
     alerts: [{type: telegram, failure-threshold: 1, success-threshold: 1, send-on-resolved: true}]
 
   - name: Home Assistant
+    enabled: true
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:


### PR DESCRIPTION
## Summary
- Remove the 03:55–04:15 ET maintenance window from `ansible/services/gatus/config.yaml.j2`. It was swallowing resolved-alert notifications when the backup-remote `curl` push landed inside the window.
- Add an explicit `enabled: true` line to every endpoint and external-endpoint so the field is visible for hand-editing to `false` during maintenance.

## Why (#64)
On May 11 backups failed and Gatus alerted (failure detected via 25h heartbeat expiry — landed outside the maintenance window). On May 12 backups succeeded but no resolved notification fired. Investigation: backup cron runs at 04:00, the gatus push at the end of `backup-remote` typically lands ~04:05–04:15, fully inside the 03:55–04:15 maintenance window. Gatus suppresses all alert notifications during a maintenance window (and does not replay them after) — so the resolve was silently dropped.

The window's only purpose was masking the 1–3 min service-down blip during `backup-execute`. The existing `failure-threshold: 3` over 5m intervals (15 min to trip) absorbs that blip without needing the window.

Note: `send-on-resolved: true` (the first half of the issue's ask) was already present on every alert — added in #61, merged six days before this issue was filed. Confirmed by `grep send-on-resolved`.

## Test plan
- [ ] After merge, run `/deploy-and-verify gatus` to roll the new config
- [ ] Verify `https://status.<domain>` shows endpoints as before (no missing items)
- [ ] On the next overnight backup cycle, simulate a failure → recovery (e.g. revoke `GATUS_BACKUP_PUSH_TOKEN` briefly) and confirm both failure and resolved Telegram alerts arrive

Closes #64