### PR TITLE
hacs: install HACS into Home Assistant via deploy-versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,22 @@ Kuma configuration is manual (no API automation). Use SQLite (the default) — n
 
 **Subsequent deploys:** Kuma data persists in `/docker-data/volumes/uptime-kuma/data` (SQLite file).
 
+### HACS Setup
+
+HACS (Home Assistant Community Store) is installed by `deploy-versions.yml` from
+the GitHub release pinned in `versions.yml` (`hacs:`). Files land in
+`/docker-data/volumes/homeassistant/custom_components/hacs/` and a
+`.installed-version` marker drives idempotency — bumping the version triggers a
+re-extract and HA restart on the next deploy.
+
+The UI side is manual (one-time per HA install):
+
+1. After the first deploy with HACS, restart HA finishes loading `custom_components/hacs/`
+2. In the HA UI: Settings → Devices & Services → Add Integration → search "HACS"
+3. Accept the prompts; HACS shows a GitHub device-code URL + code
+4. Open the URL on any browser signed into GitHub, paste the code, authorize
+5. HACS appears in the sidebar; integrations installed through it are managed by HACS from then on
+
 ### Beszel Agent Bootstrap
 
 Beszel agents authenticate with the hub using the hub's SSH public key (`KEY`) and a token (`TOKEN`). We use a **universal token** so any agent can auto-register with the hub on first connect — no per-system setup needed. Both values are stored in the Infisical Runtime project as `BESZEL_AGENT_KEY` and `BESZEL_AGENT_TOKEN`, and are pulled by `deploy-versions.yml`.

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -239,14 +239,62 @@
         mode: '0644'
       when: "'traefik' in _enabled_services"
 
+    # ── Install HACS into Home Assistant custom_components ───────────────────
+    # HACS is delivered as a release zip from GitHub, not a Docker image. We
+    # extract it under HA's config volume and use a version marker so reinstall
+    # only happens on a version bump. A changed marker registers homeassistant
+    # as changed below, triggering a restart.
+
+    - name: Read installed HACS version marker
+      ansible.builtin.slurp:
+        src: "{{ data_disk_mountpoint }}/volumes/homeassistant/custom_components/hacs/.installed-version"
+      register: _hacs_installed
+      failed_when: false
+      when: "'homeassistant' in _enabled_services"
+
+    - name: Install or upgrade HACS
+      when:
+        - "'homeassistant' in _enabled_services"
+        - (_hacs_installed.content | default('') | b64decode | trim) != versions.hacs
+      block:
+        - name: Ensure HACS directory exists
+          ansible.builtin.file:
+            path: "{{ data_disk_mountpoint }}/volumes/homeassistant/custom_components/hacs"
+            state: directory
+            owner: root
+            group: root
+            mode: '0755'
+
+        - name: Extract HACS release zip
+          ansible.builtin.unarchive:
+            src: "https://github.com/hacs/integration/releases/download/{{ versions.hacs }}/hacs.zip"
+            dest: "{{ data_disk_mountpoint }}/volumes/homeassistant/custom_components/hacs"
+            remote_src: true
+            owner: root
+            group: root
+
+        - name: Write HACS version marker
+          ansible.builtin.copy:
+            content: "{{ versions.hacs }}\n"
+            dest: "{{ data_disk_mountpoint }}/volumes/homeassistant/custom_components/hacs/.installed-version"
+            owner: root
+            group: root
+            mode: '0644'
+
+        - name: Mark homeassistant as changed for HACS install
+          ansible.builtin.set_fact:
+            _hacs_changed: true
+
     # ── Determine what changed ────────────────────────────────────────────────
 
     - name: Determine changed services
       ansible.builtin.set_fact:
         _changed_services: >-
-          {{ _file_results.results
-             | selectattr('changed')
-             | map(attribute='item.service')
+          {{ (_file_results.results
+              | selectattr('changed')
+              | map(attribute='item.service')
+              | list
+              + (['homeassistant'] if _hacs_changed | default(false) else []))
              | unique | list }}
 
     - name: Nothing to do

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -37,6 +37,9 @@ versions:
   # https://hub.docker.com/r/homeassistant/home-assistant/tags — "stable" tracks latest stable monthly release
   homeassistant: "stable"
 
+  # https://github.com/hacs/integration/releases — pinned; installed into HA custom_components/
+  hacs: "2.0.5"
+
   # https://github.com/Koenkk/zigbee2mqtt/releases — floating major
   zigbee2mqtt: "2"
 


### PR DESCRIPTION
## Summary
- Pin `hacs: \"2.0.5\"` in `ansible/versions.yml`
- Add an HACS install block to `deploy-versions.yml` that extracts the release zip into HA's `custom_components/hacs/` on the data volume, gated by a `.installed-version` marker for idempotency; a version bump folds into `_changed_services` and restarts HA
- Document the one-time GitHub OAuth device-code setup in `CLAUDE.md` (alongside Kuma/Beszel)

## Test plan
- [x] First run: HACS installed (changed=6), HA restarted, container Up, HA logs show `custom integration hacs` loaded — no errors
- [x] Re-run: idempotent (changed=0, skipped=12) — install block skipped because marker matches
- [x] Complete UI setup: Settings → Devices & Services → Add Integration → HACS → GitHub device-code flow
- [ ] Bump `hacs:` in a future PR and confirm HA restarts on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)