### PR TITLE
versions: bump traefik to v3.7 stream, dockhand to v1.0.31

### DIFF
--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -11,7 +11,7 @@
 
 versions:
   # https://github.com/traefik/traefik/releases — floating minor
-  traefik: "v3.6"
+  traefik: "v3.7"
 
   # https://github.com/immich-app/immich/releases — pinned (rapid breaking changes)
   immich: "v2.7.5"
@@ -29,7 +29,7 @@ versions:
   beszel: "0.18.7"
 
   # https://hub.docker.com/r/fnsys/dockhand/tags — pinned (small project)
-  dockhand: "v1.0.27"
+  dockhand: "v1.0.31"
 
   # https://hub.docker.com/r/willfarrell/autoheal — pinned (rarely updated)
   autoheal: "1.2.0"


### PR DESCRIPTION
## Summary
- traefik: `v3.6` → `v3.7` (floating minor — moves to v3.7 release stream)
- dockhand: `v1.0.27` → `v1.0.31`

## Why
Routine version bumps requested in #73.

## Test plan
- [x] After merge: `/deploy-and-verify` to pull new images and confirm both services come up healthy

Closes #73