### PR TITLE
bentopdf: add BentoPDF PDF toolkit service alongside Stirling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ All runtime secrets are stored in **Infisical** (project: "Swintronics Runtime",
 | immich         | immich-app     | services/immich-app/compose.yml.j2    |
 | paperless      | paperless      | services/paperless/compose.yml.j2     |
 | stirling-pdf   | stirling-pdf   | services/stirling-pdf/compose.yml.j2  |
+| bentopdf       | bentopdf       | services/bentopdf/compose.yml.j2      |
 | traefik        | networking     | services/networking/traefik.yml.j2    |
 | autoheal       | autoheal       | services/autoheal/compose.yml.j2      |
 | homeassistant  | homeassistant  | services/homeassistant/compose.yml.j2 |

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -65,6 +65,12 @@
         files:
           - { src: compose.yml.j2,  dest: compose.yml }
           - { src: .env.j2,         dest: .env,               secret: true }
+      bentopdf:
+        dir: bentopdf
+        dns_names: [bentopdf]
+        files:
+          - { src: compose.yml.j2,  dest: compose.yml }
+          - { src: .env.j2,         dest: .env,               secret: true }
       beszel:
         dir: beszel
         dns_names: [beszel]

--- a/ansible/playbooks/setup-storage.yml
+++ b/ansible/playbooks/setup-storage.yml
@@ -30,6 +30,7 @@
       paperless:   { dir: paperless,    stateful: true  }
       gatus:       { dir: gatus,        stateful: true  }
       stirling_pdf: { dir: stirling-pdf, stateful: false }
+      bentopdf:    { dir: bentopdf,     stateful: false }
       beszel:      { dir: beszel,       stateful: true  }
       dockhand:      { dir: dockhand,       stateful: true  }
       homeassistant: { dir: homeassistant,  stateful: true  }

--- a/ansible/services/bentopdf/.env.j2
+++ b/ansible/services/bentopdf/.env.j2
@@ -1,0 +1,4 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+SERVER_DOMAIN={{ server_domain }}
+CERT_RESOLVER={{ cert_resolver }}
+TZ={{ timezone }}

--- a/ansible/services/bentopdf/compose.yml.j2
+++ b/ansible/services/bentopdf/compose.yml.j2
@@ -1,0 +1,24 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+
+name: bentopdf
+include:
+  - ../networks.yml
+
+services:
+  bentopdf:
+    container_name: bentopdf
+    image: ghcr.io/alam00000/bentopdf-simple:{{ versions.bentopdf }}
+    environment:
+      - TZ=${TZ:-America/New_York}
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    labels:
+      traefik.enable: true
+      traefik.http.routers.bentopdf.entrypoints: websecure
+      traefik.http.routers.bentopdf.rule: Host(`{{ _service_config.bentopdf.dns_names[0] }}.{{ server_domain }}`)
+      traefik.http.routers.bentopdf.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.services.bentopdf.loadbalancer.server.port: 8080

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -38,6 +38,14 @@ endpoints:
     conditions: ["[STATUS] == 200"]
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
+  - name: BentoPDF
+    enabled: true
+    group: Services
+    url: https://bentopdf.{{ server_domain }}/
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
   - name: Home Assistant
     enabled: true
     group: Services

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -25,6 +25,9 @@ versions:
   # https://github.com/Stirling-Tools/Stirling-PDF/releases — pinned
   stirling_pdf: "2.10.0"
 
+  # https://github.com/alam00000/bentopdf/releases — pinned (fast-moving)
+  bentopdf: "v2.8.5"
+
   # https://github.com/henrygd/beszel/releases — pinned (pre-1.0)
   beszel: "0.18.7"
 


### PR DESCRIPTION
## Summary
- Add **BentoPDF** (`ghcr.io/alam00000/bentopdf-simple`, pinned `v2.8.5`) as a new stateless service modeled on `stirling-pdf` — `compose.yml.j2` + `.env.j2`.
- Wire it into `deploy-versions.yml` (`_service_config`), `setup-storage.yml` (stateless), a **Gatus** monitor (`bentopdf.<domain>`), and the CLAUDE.md service-name mapping.
- Pinned in `versions.yml` (fast-moving project).

## Why
Issue #75 asks for a Bento PDF service — BentoPDF is a privacy-first, fully client-side PDF toolkit and a Stirling-PDF alternative. Per discussion, this adds it **alongside** Stirling-PDF (both stay running) so the two can be compared live; removing Stirling is deferred to a follow-up PR/issue.

## Notes
- `cluster.sh` is intentionally **not** touched — it's a stale legacy script that already omits every modern service (gatus, beszel, homeassistant, …); `deploy-versions.yml` is the actual deploy path.
- BentoPDF is client-side: no volumes or env required; Traefik routes to internal port `8080`. Gatus monitor checks `GET /` for `200`.

## Verification (local, pre-merge)
- `ansible-playbook --syntax-check` passes for `deploy-versions.yml` and `setup-storage.yml`.
- Jinja render of `compose.yml.j2` → valid YAML, image tag and `bentopdf.<domain>` route resolve correctly.

## Test plan
- [x] After merge: `/deploy-and-verify bentopdf`
- [ ] Confirm `https://bentopdf.<domain>` loads and a basic PDF op works
- [ ] Confirm Gatus shows the BentoPDF endpoint green

Closes #75