### PR TITLE
versions: bump dockhand v1.0.31→v1.0.34

### DIFF
--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -32,7 +32,7 @@ versions:
   beszel: "0.18.7"
 
   # https://hub.docker.com/r/fnsys/dockhand/tags — pinned (small project)
-  dockhand: "v1.0.31"
+  dockhand: "v1.0.34"
 
   # https://hub.docker.com/r/willfarrell/autoheal — pinned (rarely updated)
   autoheal: "1.2.0"


### PR DESCRIPTION
Bump dockhand v1.0.31 → v1.0.34.

Deployed to swintronics (XPS13) and verified before merge:
- ✓ rendered compose file landed
- ✓ container running (Up, healthy)
- ✓ image tag matches versions.yml (`fnsys/dockhand:v1.0.34`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)