### PR TITLE
gatus: disable monitors for services in disabled_services

### DIFF
--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -52,7 +52,10 @@ stateless web app, `paperless` for stateful with DB + backups).
 - `ansible/playbooks/setup-storage.yml` — `_service_storage` entry
   (`stateful: true` → btrfs subvolume; `false` → logs dir only)
 - `ansible/services/gatus/config.yaml.j2` — endpoint block (copy an existing
-  one; use a lightweight health/status URL, Telegram alerts); lowercase keys
+  one; use a lightweight health/status URL, Telegram alerts); lowercase keys;
+  make `enabled:` conditional on the service key so disabling the service
+  also pauses its monitor:
+  `enabled: {{ ('<service-key>' not in disabled_services | default([])) | lower }}`
 - `CLAUDE.md` — row in the Service Name Mapping table; update the
   upstream-compose convention list
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,9 @@ Matched pair of Claude Code skills drives the service lifecycle:
   snapshots are never touched — the service just stops being backed up.
 
 To temporarily disable a service instead (keep files and data, stop
-containers), add it to `disabled_services` in `ansible/versions.yml`.
+containers), add it to `disabled_services` in `ansible/versions.yml`. The
+Gatus config template reads the same list, so the service's monitors are
+disabled on the same deploy (and re-enabled when the name is removed).
 
 ### Networking
 

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -15,7 +15,7 @@ alerting:
 endpoints:
   # ── Services (5m, 3 retries) ──────────────────────────────────────────────
   - name: Immich
-    enabled: true
+    enabled: {{ ('immich' not in disabled_services | default([])) | lower }}
     group: Services
     url: https://photos.{{ server_domain }}/api/server/ping
     interval: 5m
@@ -23,7 +23,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Paperless
-    enabled: true
+    enabled: {{ ('paperless' not in disabled_services | default([])) | lower }}
     group: Services
     url: https://paperless.{{ server_domain }}/accounts/login/
     interval: 5m
@@ -31,7 +31,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: BentoPDF
-    enabled: true
+    enabled: {{ ('bentopdf' not in disabled_services | default([])) | lower }}
     group: Services
     url: https://bentopdf.{{ server_domain }}/
     interval: 5m
@@ -39,7 +39,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Home Assistant
-    enabled: true
+    enabled: {{ ('homeassistant' not in disabled_services | default([])) | lower }}
     group: Services
     url: https://ha.{{ server_domain }}/
     interval: 5m
@@ -47,7 +47,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Zigbee2MQTT
-    enabled: true
+    enabled: {{ ('zigbee2mqtt' not in disabled_services | default([])) | lower }}
     group: Services
     url: https://z2m.{{ server_domain }}/
     interval: 5m
@@ -56,7 +56,7 @@ endpoints:
 
   # ── System Monitoring (5m, 3 retries) ─────────────────────────────────────
   - name: Traefik
-    enabled: true
+    enabled: {{ ('traefik' not in disabled_services | default([])) | lower }}
     group: System Monitoring
     url: https://traefik.{{ server_domain }}/api/version
     interval: 5m
@@ -64,7 +64,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Dockhand
-    enabled: true
+    enabled: {{ ('dockhand' not in disabled_services | default([])) | lower }}
     group: System Monitoring
     url: https://dockhand.{{ server_domain }}/api/health
     interval: 5m
@@ -72,7 +72,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Beszel
-    enabled: true
+    enabled: {{ ('beszel' not in disabled_services | default([])) | lower }}
     group: System Monitoring
     url: https://beszel.{{ server_domain }}/api/health
     interval: 5m
@@ -80,7 +80,7 @@ endpoints:
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
   - name: Beszel agent
-    enabled: true
+    enabled: {{ ('beszel' not in disabled_services | default([])) | lower }}
     group: System Monitoring
     url: tcp://host.docker.internal:45876
     interval: 5m


### PR DESCRIPTION
## Summary
- Each service HTTP endpoint in `ansible/services/gatus/config.yaml.j2` now renders `enabled:` from `disabled_services` (loaded via `vars_files` in `deploy-versions.yml`), keyed on the service key (`bentopdf`, `homeassistant`, …). The Beszel agent endpoint keys off `beszel` since agent and hub deploy together; the Healthchecks.io heartbeat endpoint is not service-tied and stays unconditional.
- `/add-service` skill now scaffolds the conditional into new endpoint blocks; CLAUDE.md's disable paragraph notes that monitors pause/resume with the service.

## Why
Adding a service to `disabled_services` stops its containers (#81/#84) but Gatus kept probing the dead service and alerting. Now the same `deploy-versions.yml` run that stops the containers re-renders the Gatus config (triggering a Gatus restart) with the monitor off — `versions.yml` stays the single source of truth, no new playbooks.

## Deliberately out of scope
The **Backups** external-endpoints stay unconditionally enabled. Backup hooks still run for disabled services (the "related gap" in #87 — and it's worse than it looks: `backup.sh`'s `backup-prepare` phase is fail-fast, so a disabled stateful service's failing prepare hook aborts the whole nightly run). Until backup participation is also rendered from `disabled_services`, the backup heartbeat alerts are the signal for that failure mode, so they were intentionally left on. Suggested follow-up: `deploy-versions.yml` drops a `.disabled` marker in the service's compose dir and `run_hooks` in `backup.sh` skips marked directories — then the Backups endpoints can go conditional too.

## Test plan
- Verified locally: rendered the template with jinja2 for `disabled_services: []` and `['bentopdf', 'zigbee2mqtt']` — output parses as valid YAML with real booleans, and exactly the listed services' monitors flip to `false`.
- [x] After merge: `/deploy-and-verify gatus` (no-op config change, all monitors stay enabled since `disabled_services` is empty)
- [ ] Optional end-to-end: add `bentopdf` to `disabled_services`, deploy, confirm the BentoPDF monitor disappears from the Gatus UI and no alert fires; revert.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)