### PR TITLE
beszel: enable autoheal for beszel-agent container

### DIFF
--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -4,12 +4,8 @@ xps13 ansible_connection=local ansible_host=localhost
 [swintronics:children]
 local
 
-[cactus_cantina]
-oci-1 ansible_host=oci-1.cactus-cantina.com
-
 [clusters:children]
 swintronics
-cactus_cantina
 
 [clusters:vars]
 ansible_python_interpreter=/usr/bin/python3

--- a/ansible/services/beszel/compose.yml.j2
+++ b/ansible/services/beszel/compose.yml.j2
@@ -37,4 +37,6 @@ services:
       KEY: "{{ beszel_agent_key }}"
       TOKEN: "{{ beszel_agent_token }}"
       HUB_URL: "https://{{ _service_config.beszel.dns_names[0] }}.{{ server_domain }}"
+    labels:
+      autoheal: "true"
 {% endif %}


### PR DESCRIPTION
Closes #80

## Summary

- Add the `autoheal: "true"` label to the `beszel-agent` service so the [autoheal](https://github.com/willfarrell/docker-autoheal) container restarts it when its healthcheck fails. The agent already defines a healthcheck (`/agent health`, 120s interval) but had no autoheal label, so a wedged agent would stay down until manually restarted.
- Drop the experimental `cactus_cantina`/OCI cluster from the Ansible inventory.

## Deploy & verify

Deployed to `swintronics` (XPS13) via `deploy-versions.yml`:

- ✓ rendered compose landed on the server with the label
- ✓ `autoheal=true` present on the running `beszel-agent` container
- ✓ both `beszel` and `beszel-agent` containers running (`henrygd/beszel:0.18.7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)