### PR TITLE
Disabled services: skip backup hooks via .disabled marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,8 +346,14 @@ Matched pair of Claude Code skills drives the service lifecycle:
 
 To temporarily disable a service instead (keep files and data, stop
 containers), add it to `disabled_services` in `ansible/versions.yml`. The
-Gatus config template reads the same list, so the service's monitors are
-disabled on the same deploy (and re-enabled when the name is removed).
+Gatus config template reads the same list, so the service's monitors —
+including its Backups heartbeat endpoint — are disabled on the same deploy
+(and re-enabled when the name is removed). The deploy also writes a
+`.disabled` marker into the service's compose directory, which makes
+`backup.sh` skip its backup hooks (the containers are down; running the hooks
+would fail or restart them). Trade-off: while disabled, the service's restic
+snapshots age toward the retention window (`--keep-daily 7` etc.) — fine for
+a temporary disable, but pre-disable snapshots eventually rotate out.
 
 ### Networking
 

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -5,7 +5,9 @@
 #
 # Services not defined in versions.yml are skipped entirely. Services listed in
 # versions.yml's `disabled_services` are stopped (`docker compose down`) while
-# their files, config, volumes, and network are left intact.
+# their files, config, volumes, and network are left intact. A `.disabled`
+# marker is written into the service's compose directory so backup.sh skips
+# its backup hooks (and removed again when the service is re-enabled).
 # Traefik is always restarted first. Uptime Kuma is stopped before any
 # restart and started after, with healthchecks.io paused for the duration.
 #
@@ -181,6 +183,27 @@
       loop: "{{ _disabled_dirs.results | selectattr('stat.exists') | list }}"
       loop_control:
         label: "{{ item.item }}"
+
+    # backup.sh's run_hooks skips any service directory containing .disabled,
+    # so a disabled service's backup hooks don't run against stopped containers.
+
+    - name: Mark disabled services so backup hooks are skipped
+      ansible.builtin.file:
+        path: "{{ docker_services_path }}/{{ _service_config[item.item].dir }}/.disabled"
+        state: touch
+        owner: "{{ admin_user }}"
+        mode: '0644'
+        modification_time: preserve
+        access_time: preserve
+      loop: "{{ _disabled_dirs.results | selectattr('stat.exists') | list }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Remove .disabled marker from enabled services
+      ansible.builtin.file:
+        path: "{{ docker_services_path }}/{{ _service_config[item].dir }}/.disabled"
+        state: absent
+      loop: "{{ _enabled_services }}"
 
     - name: Deploy shared networks.yml
       ansible.builtin.copy:

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -98,8 +98,10 @@ endpoints:
 
 external-endpoints:
   # ── Backups (push from backup-remote scripts, alert if no ping in 25h) ─────
+  # Disabled services skip their backup hooks (.disabled marker), so their
+  # heartbeat endpoints are disabled too — otherwise they'd alert after 25h.
   - name: Immich
-    enabled: true
+    enabled: {{ ('immich' not in disabled_services | default([])) | lower }}
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:
@@ -107,7 +109,7 @@ external-endpoints:
     alerts: [{type: telegram, failure-threshold: 1, success-threshold: 1, send-on-resolved: true}]
 
   - name: Paperless
-    enabled: true
+    enabled: {{ ('paperless' not in disabled_services | default([])) | lower }}
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:
@@ -115,7 +117,7 @@ external-endpoints:
     alerts: [{type: telegram, failure-threshold: 1, success-threshold: 1, send-on-resolved: true}]
 
   - name: Home Assistant
-    enabled: true
+    enabled: {{ ('homeassistant' not in disabled_services | default([])) | lower }}
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:

--- a/docker-services/backup.sh
+++ b/docker-services/backup.sh
@@ -51,6 +51,14 @@ run_hooks() {
     local continue_on_error="${2:-false}"
     echo "━━ Phase: ${hook} ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     for dir in "${DOCKER_SERVICES}"/*/; do
+        # deploy-versions.yml marks disabled_services with a .disabled file;
+        # their containers are down, so running hooks would fail or restart them
+        if [ -e "${dir}/.disabled" ]; then
+            if [ -x "${dir}/${hook}" ]; then
+                echo "⏭ ${hook}: $(basename "${dir}") (disabled — skipped)"
+            fi
+            continue
+        fi
         if [ -x "${dir}/${hook}" ]; then
             local service rc=0
             service=$(basename "${dir}")


### PR DESCRIPTION
## Summary
- `deploy-versions.yml` writes a `.disabled` marker into each disabled service's compose directory (idempotent touch) and removes it from enabled services, so re-enabling resumes backups on the same deploy
- `backup.sh`'s `run_hooks` skips any service directory containing `.disabled`, logging a "⏭ skipped" line when a hook would have run
- Gatus Backups external-endpoints (Immich, Paperless, Home Assistant) are now conditional on `disabled_services` — closes the loop deliberately left open in #88, where a disabled service would fire a 25h heartbeat alert once its backups stopped
- CLAUDE.md disable paragraph extended: backups pause too, plus the accepted retention-window trade-off (pre-disable snapshots eventually rotate out)

## Why
Per the failure analysis on #89: `disabled_services` does `docker compose down`, but the nightly `backup.sh` still ran the service's hooks. A disabled paperless aborted the entire backup run in the fail-fast `backup-prepare` phase (no service got backed up), and a disabled immich was partially un-disabled (`up -d database`) then aborted the run anyway. Skipping centrally via the marker beats per-hook defensive checks — any backup of a downed service is stale-prep data.

## Test plan
- [x] `ansible-playbook playbooks/deploy-versions.yml --syntax-check`
- [x] `shellcheck` + `bash -n` on `backup.sh`
- [x] Local Jinja render of `config.yaml.j2` with `disabled_services=['paperless']` → valid YAML, only Paperless backup endpoint disabled
- [ ] After merge: `/deploy-and-verify gatus` **and** `ansible-playbook playbooks/install-backup.yml` (backup.sh is deployed by install-backup, not deploy-versions)
- [ ] Disable a service in `versions.yml`, deploy, confirm `.disabled` marker exists and next backup run logs the skip; re-enable and confirm marker removed

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)