### PR TITLE
memos: add service (compose, backups, Gatus, storage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,7 @@ All runtime secrets are stored in **Infisical** (project: "Swintronics Runtime",
 | homeassistant  | homeassistant  | services/homeassistant/compose.yml.j2 |
 | zigbee2mqtt    | zigbee2mqtt    | services/zigbee2mqtt/compose.yml.j2   |
 | mosquitto      | mosquitto      | services/mosquitto/compose.yml.j2     |
+| memos          | memos          | services/memos/compose.yml.j2         |
 | beszel         | beszel         | services/beszel/compose.yml.j2        |
 | dockhand       | dockhand       | services/dockhand/compose.yml.j2      |
 | gatus          | gatus          | services/gatus/compose.yml.j2         |
@@ -546,4 +547,4 @@ This scenario requires additional planning around Restic repo sharing and is def
 - Long-term: phone-friendly server management — expose remaining service UIs, document mobile access patterns
 
 ### Upstream Compose File Convention
-Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich, paperless, uptime-kuma, beszel. Not tracked: networking/traefik (fully custom), dockhand (single-container, written from scratch)
+Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich, paperless, uptime-kuma, beszel, memos. Not tracked: networking/traefik (fully custom), dockhand (single-container, written from scratch)

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -105,6 +105,14 @@
         files:
           - { src: compose.yml.j2,    dest: compose.yml }
           - { src: mosquitto.conf.j2, dest: mosquitto.conf }
+      memos:
+        dir: memos
+        dns_names: [memos]
+        files:
+          - { src: compose.yml.j2,  dest: compose.yml }
+          - { src: .env.j2,         dest: .env,            secret: true }
+          - { src: backup-execute,  dest: backup-execute,  executable: true }
+          - { src: backup-remote,   dest: backup-remote,   executable: true }
 
   pre_tasks:
     - name: Determine disabled services

--- a/ansible/playbooks/setup-storage.yml
+++ b/ansible/playbooks/setup-storage.yml
@@ -35,6 +35,7 @@
       homeassistant: { dir: homeassistant,  stateful: true  }
       zigbee2mqtt:   { dir: zigbee2mqtt,    stateful: true  }
       mosquitto:     { dir: mosquitto,      stateful: true  }
+      memos:         { dir: memos,          stateful: true  }
 
   pre_tasks:
     - name: Load versions

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -54,6 +54,14 @@ endpoints:
     conditions: ["[STATUS] == 200"]
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
+  - name: Memos
+    enabled: {{ ('memos' not in disabled_services | default([])) | lower }}
+    group: Services
+    url: https://memos.{{ server_domain }}/healthz
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
   # ── System Monitoring (5m, 3 retries) ─────────────────────────────────────
   - name: Traefik
     enabled: {{ ('traefik' not in disabled_services | default([])) | lower }}
@@ -118,6 +126,14 @@ external-endpoints:
 
   - name: Home Assistant
     enabled: {{ ('homeassistant' not in disabled_services | default([])) | lower }}
+    group: Backups
+    token: ${GATUS_BACKUP_PUSH_TOKEN}
+    heartbeat:
+      interval: 25h
+    alerts: [{type: telegram, failure-threshold: 1, success-threshold: 1, send-on-resolved: true}]
+
+  - name: Memos
+    enabled: {{ ('memos' not in disabled_services | default([])) | lower }}
     group: Backups
     token: ${GATUS_BACKUP_PUSH_TOKEN}
     heartbeat:

--- a/ansible/services/memos/.env.j2
+++ b/ansible/services/memos/.env.j2
@@ -1,0 +1,4 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+SERVER_DOMAIN={{ server_domain }}
+CERT_RESOLVER={{ cert_resolver }}
+TZ={{ timezone }}

--- a/ansible/services/memos/backup-execute
+++ b/ansible/services/memos/backup-execute
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+# Stop memos, snapshot its volume, restart.
+# Healthchecks are already paused by the orchestrator.
+
+DATA="${DATA_MOUNTPOINT:-/mnt/docker-data}"
+SNAP="${DATA}/snapshots/memos/backup"
+
+mkdir -p "$(dirname "${SNAP}")"
+
+if [ "$(stat --format=%i "${SNAP}" 2>/dev/null)" = "256" ]; then
+    sudo btrfs property set "${SNAP}" ro false
+    sudo btrfs subvolume delete "${SNAP}"
+fi
+if [ -e "${SNAP}" ]; then
+    echo "ERROR: could not remove previous snapshot at ${SNAP}" >&2; exit 1
+fi
+
+echo "Stopping memos..."
+docker compose stop memos
+
+echo "Creating snapshot..."
+sudo btrfs subvolume snapshot -r "${DATA}/volumes/memos" "${SNAP}"
+
+echo "Starting memos..."
+docker compose start memos

--- a/ansible/services/memos/backup-remote
+++ b/ansible/services/memos/backup-remote
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+# Upload memos snapshot to restic and ping monitoring endpoint.
+
+DATA="${DATA_MOUNTPOINT:-/mnt/docker-data}"
+SNAP="${DATA}/snapshots/memos/backup"
+ARCHIVE="${DATA}/snapshots/memos/${DAY:-$(date +%A)}"
+GATUS_ENDPOINT="backups_memos"
+
+push_gatus() {
+    local success="$1"
+    [ -n "${GATUS_BASE_URL:-}" ] || return 0
+    curl -fsS -o /dev/null --retry 3 \
+        -X POST -H "Authorization: Bearer ${GATUS_BACKUP_PUSH_TOKEN}" \
+        "${GATUS_BASE_URL}/api/v1/endpoints/${GATUS_ENDPOINT}/external?success=${success}" || true
+}
+
+trap 'push_gatus false' ERR
+
+echo "Uploading memos snapshot to restic..."
+sudo -E restic backup --retry-lock 10m --tag memos --tag "${DATE:-$(date +%F_%H-%M)}" "${SNAP}"
+sudo -E restic forget --retry-lock 10m --tag memos --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
+sudo -E restic check --retry-lock 10m
+
+if [ "$(stat --format=%i "${ARCHIVE}" 2>/dev/null)" = "256" ]; then
+    sudo btrfs property set "${ARCHIVE}" ro false
+    sudo btrfs subvolume delete "${ARCHIVE}"
+fi
+if [ -e "${ARCHIVE}" ]; then
+    echo "ERROR: could not remove previous archive at ${ARCHIVE}" >&2; exit 1
+fi
+mv "${SNAP}" "${ARCHIVE}"
+
+push_gatus true

--- a/ansible/services/memos/compose.yml.j2
+++ b/ansible/services/memos/compose.yml.j2
@@ -1,0 +1,26 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+
+name: memos
+include:
+  - ../networks.yml
+
+services:
+  memos:
+    container_name: memos
+    image: neosmemo/memos:{{ versions.memos }}
+    environment:
+      - TZ=${TZ:-America/New_York}
+    volumes:
+      - {{ data_disk_mountpoint }}/volumes/memos:/var/opt/memos
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:5230/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    labels:
+      traefik.enable: true
+      traefik.http.routers.memos.entrypoints: websecure
+      traefik.http.routers.memos.rule: Host(`{{ _service_config.memos.dns_names[0] }}.{{ server_domain }}`)
+      traefik.http.routers.memos.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.services.memos.loadbalancer.server.port: 5230

--- a/ansible/services/memos/upstream.yml
+++ b/ansible/services/memos/upstream.yml
@@ -1,0 +1,8 @@
+services:
+  memos:
+    image: neosmemo/memos:stable
+    container_name: memos
+    volumes:
+      - ~/.memos/:/var/opt/memos
+    ports:
+      - 5230:5230

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -46,6 +46,9 @@ versions:
   # https://hub.docker.com/_/mosquitto — floating major (extremely stable)
   mosquitto: "2"
 
+  # https://github.com/usememos/memos/releases — pinned (pre-1.0)
+  memos: "0.29.1"
+
 # Services listed here are stopped by deploy-versions (`docker compose down`)
 # while their compose files, config, volumes, and Docker network are left
 # intact. Remove a name to re-enable — the next deploy redeploys and restarts


### PR DESCRIPTION
Adds Memos (github.com/usememos/memos) as a new service — also the test vehicle for the planned add/disable/re-enable/delete lifecycle exercise.

- `neosmemo/memos:0.29.1` (pinned, pre-1.0), SQLite state under `/docker-data/volumes/memos`, `/healthz` healthcheck, Traefik routing at `memos.<domain>`
- `backup-execute`/`backup-remote` hooks on the homeassistant pattern (btrfs snapshot → restic, `backups_memos` Gatus heartbeat) so the disabled-services `.disabled` skip path (#94) gets exercised
- Gatus Services + Backups endpoints conditional on `disabled_services`

🤖 Generated with [Claude Code](https://claude.com/claude-code)