### PR TITLE
memos: disable (lifecycle test step 3)

### DIFF
--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -54,4 +54,5 @@ versions:
 # intact. Remove a name to re-enable — the next deploy redeploys and restarts
 # it. Names must match the service keys above / the playbook's _service_config
 # (e.g. bentopdf, dockhand).
-disabled_services: []
+disabled_services:
+  - memos


### PR DESCRIPTION
Lifecycle test step 3 — disable memos via disabled_services. Verifies compose down, .disabled marker, and conditional Gatus endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)