### PR TITLE
memos: re-enable (lifecycle test step 4)

### DIFF
--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -54,5 +54,4 @@ versions:
 # intact. Remove a name to re-enable — the next deploy redeploys and restarts
 # it. Names must match the service keys above / the playbook's _service_config
 # (e.g. bentopdf, dockhand).
-disabled_services:
-  - memos
+disabled_services: []


### PR DESCRIPTION
Lifecycle test step 4 — re-enable memos. Verifies data survival, .disabled marker removal, Gatus endpoints back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)