### PR TITLE
delete-service: clean up local snapshot staging area

### DIFF
--- a/.claude/skills/delete-service/SKILL.md
+++ b/.claude/skills/delete-service/SKILL.md
@@ -59,7 +59,9 @@ ansible-playbook playbooks/delete-service.yml \
 
 `volume_dir` defaults to `service_dir`; pass it only when they differ. The
 playbook stops and removes containers + named volumes, deletes the compose
-directory, data volumes, and logs, prunes images, and deletes the CNAMEs.
+directory, data volumes, logs, and the local snapshot staging area
+(`<data_disk_mountpoint>/snapshots/<volume_dir>`), prunes images, and deletes
+the CNAMEs.
 
 Then run `deploy-versions.yml` (or `/deploy-and-verify gatus`) so Gatus is
 re-rendered without the deleted service's monitor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,8 +341,9 @@ Matched pair of Claude Code skills drives the service lifecycle:
 - **`/delete-service <name>`** — the reverse: removes the repo config and doc
   references, then runs `ansible-playbook playbooks/delete-service.yml
   -e service_dir=<dir>` to tear down the server side (containers + named
-  volumes, compose directory, data volumes, logs, DNS CNAMEs). Existing restic
-  snapshots are never touched — the service just stops being backed up.
+  volumes, compose directory, data volumes, logs, local snapshot staging area,
+  DNS CNAMEs). Existing restic snapshots are never touched — the service just
+  stops being backed up.
 
 To temporarily disable a service instead (keep files and data, stop
 containers), add it to `disabled_services` in `ansible/versions.yml`. The

--- a/ansible/playbooks/delete-service.yml
+++ b/ansible/playbooks/delete-service.yml
@@ -1,7 +1,9 @@
 ---
 # Completely delete a service from the target server: stop and remove its
 # containers (including named volumes), delete its compose project directory,
-# its data volumes, and its logs, and remove its Cloudflare DNS records.
+# its data volumes, its logs, and its local snapshot staging area
+# (<data_disk_mountpoint>/snapshots/<service>), and remove its Cloudflare DNS
+# records.
 #
 # Existing restic snapshots are NOT touched — deleting the compose directory
 # removes the service's backup-* hooks, so it simply stops being backed up.
@@ -71,6 +73,28 @@
       ansible.builtin.file:
         path: "{{ data_disk_mountpoint }}/logs/{{ _volume_dir }}"
         state: absent
+
+    # The backup hooks stage read-only btrfs snapshots here (backup-execute
+    # creates <dir>/backup, backup-remote archives it as <dir>/<Day>, possibly
+    # nested, e.g. immich/library/backup). `file: state: absent` cannot remove
+    # ro subvolumes, so flip ro off and delete each subvolume first.
+    - name: Delete local snapshot staging area
+      ansible.builtin.shell: |
+        set -euo pipefail
+        dir="{{ data_disk_mountpoint }}/snapshots/{{ _volume_dir }}"
+        [ -d "${dir}" ] || exit 0
+        if [ "$(stat -f --format=%T "${dir}")" = "btrfs" ]; then
+            find "${dir}" -depth -inum 256 -type d | while read -r snap; do
+                btrfs property set "${snap}" ro false
+                btrfs subvolume delete "${snap}"
+            done
+        fi
+        rm -rf "${dir}"
+        echo "removed ${dir}"
+      args:
+        executable: /bin/bash
+      register: _snapshot_cleanup
+      changed_when: _snapshot_cleanup.stdout | length > 0
 
     - name: Prune unused Docker images
       community.docker.docker_prune:


### PR DESCRIPTION
## Summary
- `delete-service.yml` now deletes `<data_disk_mountpoint>/snapshots/<volume_dir>` — the local staging area the `backup-execute`/`backup-remote` hooks populate with read-only btrfs subvolumes
- On btrfs hosts (guarded by `stat -f %T`), each subvolume under the dir is found via inode 256 (deepest first, covering nested layouts like `immich/library/backup` and per-day archives), flipped rw, and deleted with `btrfs subvolume delete`; the parent dir is then removed. Non-btrfs hosts fall through to plain `rm -rf`
- Teardown lists in the playbook header, `/delete-service` SKILL.md, and CLAUDE.md updated to mention the staging area

## Why
Found during the memos lifecycle test (#101): after `/delete-service memos`, a stale ro subvolume `snapshots/memos/Tuesday` was left behind and had to be removed manually, since `file: state: absent` cannot delete ro subvolumes. Affects any snapshot-backed service (homeassistant, immich, zigbee2mqtt) if ever deleted.

## Test plan
- [x] `ansible-playbook playbooks/delete-service.yml --syntax-check`
- [x] `ansible-lint` passes at the production profile
- [x] Non-btrfs path exercised against a tmp dir (guard skipped, `rm -rf` cleans up)
- [x] Read-only `find -inum 256` on the live XPS13 correctly lists all real staging snapshots; `stat -f %T /docker-data` returns `btrfs`, matching the guard
- [ ] Not tested end-to-end: actual ro-subvolume deletion requires deleting a real service; verify on the next `/delete-service` run

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)