### PR TITLE
Playbook to delete a removed service's restic snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,10 @@ Matched pair of Claude Code skills drives the service lifecycle:
   -e service_dir=<dir>` to tear down the server side (containers + named
   volumes, compose directory, data volumes, logs, local snapshot staging area,
   DNS CNAMEs). Existing restic snapshots are never touched — the service just
-  stops being backed up.
+  stops being backed up. To permanently delete the snapshot history later and
+  reclaim B2 space, run `ansible-playbook playbooks/delete-backups.yml
+  -e service_tag=<name>` (lists the matching snapshots; add `-e confirm=yes`
+  to forget and prune them).
 
 To temporarily disable a service instead (keep files and data, stop
 containers), add it to `disabled_services` in `ansible/versions.yml`. The

--- a/ansible/playbooks/delete-backups.yml
+++ b/ansible/playbooks/delete-backups.yml
@@ -1,0 +1,102 @@
+---
+# Permanently delete a removed service's restic snapshots.
+#
+# delete-service.yml deliberately leaves restic snapshots untouched, and they
+# never age out on their own: forget --keep-* runs per-tag in each service's
+# backup-remote hook, so once a service is deleted its tag is no longer
+# forgotten or pruned. This playbook is the explicit second decision that
+# deletes that snapshot history and reclaims repository space.
+#
+# Lists the matching snapshots first and deletes nothing unless confirm=yes
+# is passed. Uses the server's existing backup.env credentials and runs
+# restic as root, matching the sudo -E restic invocations in the hooks.
+#
+# Usage:
+#   # List the snapshots that would be deleted:
+#   ansible-playbook playbooks/delete-backups.yml -e service_tag=memos
+#
+#   # Forget them and prune the repository:
+#   ansible-playbook playbooks/delete-backups.yml -e service_tag=memos -e confirm=yes
+#
+# Vars:
+#   service_tag  (required) restic tag the snapshots were created with — the
+#                service name used in its backup-remote hook
+#   confirm      (optional) must be "yes" to actually delete
+
+- name: Delete a removed service's restic snapshots
+  hosts: "{{ target | default('clusters') }}"
+  connection: "{{ 'local' if inventory_hostname in groups.get('local', []) else 'ssh' }}"
+  become: true
+
+  pre_tasks:
+    - name: Require service_tag
+      ansible.builtin.assert:
+        that:
+          - service_tag is defined
+          - service_tag | length > 0
+        fail_msg: "Pass -e service_tag=<restic tag> (the service name used by its backup-remote hook)"
+
+    - name: Check for backup.env
+      ansible.builtin.stat:
+        path: "{{ docker_services_path }}/backup.env"
+      register: _backup_env
+
+    - name: Require backup.env
+      ansible.builtin.assert:
+        that: _backup_env.stat.exists
+        fail_msg: "{{ docker_services_path }}/backup.env not found — run install-backup.yml first"
+
+  tasks:
+    - name: List snapshots matching tag
+      ansible.builtin.shell: |
+        set -euo pipefail
+        . "{{ docker_services_path }}/backup.env"
+        restic snapshots --retry-lock 10m --tag {{ service_tag | quote }}
+      args:
+        executable: /bin/bash
+      register: _snapshots
+      changed_when: false
+
+    - name: Collect snapshot IDs
+      ansible.builtin.shell: |
+        set -euo pipefail
+        . "{{ docker_services_path }}/backup.env"
+        restic snapshots --retry-lock 10m --tag {{ service_tag | quote }} --json |
+          python3 -c 'import json,sys; print(" ".join(s["id"] for s in (json.load(sys.stdin) or [])))'
+      args:
+        executable: /bin/bash
+      register: _snapshot_ids
+      changed_when: false
+
+    - name: Report when no snapshots match
+      ansible.builtin.debug:
+        msg: "No snapshots tagged '{{ service_tag }}' — nothing to delete."
+      when: _snapshot_ids.stdout | trim | length == 0
+
+    - name: End host when nothing to delete
+      ansible.builtin.meta: end_host
+      when: _snapshot_ids.stdout | trim | length == 0
+
+    - name: Show snapshots to be deleted
+      ansible.builtin.debug:
+        msg: "{{ _snapshots.stdout_lines }}"
+
+    - name: Require explicit confirmation
+      ansible.builtin.assert:
+        that: confirm | default(false) | bool
+        fail_msg: >-
+          Nothing deleted. Re-run with -e confirm=yes to forget the snapshots
+          listed above and prune the repository.
+
+    - name: Forget snapshots and prune repository
+      ansible.builtin.shell: |
+        set -euo pipefail
+        . "{{ docker_services_path }}/backup.env"
+        restic forget --retry-lock 10m --prune {{ _snapshot_ids.stdout | trim }}
+      args:
+        executable: /bin/bash
+      register: _forget
+
+    - name: Show forget output
+      ansible.builtin.debug:
+        msg: "{{ _forget.stdout_lines }}"

--- a/ansible/playbooks/delete-service.yml
+++ b/ansible/playbooks/delete-service.yml
@@ -7,7 +7,7 @@
 #
 # Existing restic snapshots are NOT touched — deleting the compose directory
 # removes the service's backup-* hooks, so it simply stops being backed up.
-# Old snapshots remain restorable until pruned separately.
+# Old snapshots remain restorable until deleted with delete-backups.yml.
 #
 # This playbook takes explicit parameters instead of reading _service_config
 # from deploy-versions.yml, so it still works after the service has been


### PR DESCRIPTION
## Summary
- New `ansible/playbooks/delete-backups.yml`: lists restic snapshots matching `-e service_tag=<name>`, requires `-e confirm=yes` before running `restic forget --prune` on them (by snapshot ID), using the server's existing `backup.env` credentials
- CLAUDE.md: document the playbook alongside the `/delete-service` section
- `delete-service.yml` header: point at `delete-backups.yml` for snapshot cleanup

## Why
`/delete-service` deliberately preserves restic snapshots (#82), but per-tag `forget --keep-*` only runs in a service's `backup-remote` hook — once a service is deleted, its snapshots never age out and B2 space is never reclaimed. This is the explicit second decision #93 proposes; #83 is the same request, filed earlier without detail.

## Test plan
- [x] `--syntax-check` and `ansible-lint` pass
- [x] List-only run on xps13 found the preserved memos snapshot and stopped at the confirmation gate (nothing deleted)
- [x] Bogus tag exits cleanly: "No snapshots tagged 'no-such-service' — nothing to delete"
- [ ] Post-merge: `ansible-playbook playbooks/delete-backups.yml -e service_tag=memos -e confirm=yes` to delete the lifecycle-test snapshot for real

Closes #93
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)