### PR TITLE
Automate dockhand updates: latest tag + daily self-update cron

### DIFF
--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -81,6 +81,7 @@
         files:
           - { src: compose.yml.j2,  dest: compose.yml }
           - { src: .env.j2,         dest: .env,               secret: true }
+          - { src: update-dockhand, dest: update-dockhand,    executable: true }
       autoheal:
         dir: autoheal
         files:
@@ -383,6 +384,33 @@
       ansible.builtin.debug:
         msg: "Updated: {{ _changed_services | join(', ') }}"
       when: _changed_services | length > 0
+
+    # ── Dockhand self-update cron ─────────────────────────────────────────────
+    # Dockhand updates other containers but not itself (issue #62), so a daily
+    # cron pulls its floating tag and recreates the container only when the
+    # image changed. Runs as root because the script reads Telegram creds from
+    # /etc/swintronics/monitoring.env. Removed when dockhand is disabled or
+    # dropped from versions.yml; the script also honors the .disabled marker.
+
+    - name: Ensure cron log directory exists
+      ansible.builtin.file:
+        path: "{{ data_disk_mountpoint }}/logs/cron"
+        state: directory
+        owner: "{{ admin_user }}"
+        group: "{{ admin_user }}"
+        mode: '0755'
+      when: "'dockhand' in _enabled_services"
+
+    - name: Install dockhand self-update cron job
+      ansible.builtin.cron:
+        name: "dockhand self-update"
+        minute: "0"
+        hour: "5"
+        job: >-
+          {{ docker_services_path }}/dockhand/update-dockhand
+          >> {{ data_disk_mountpoint }}/logs/cron/dockhand-update.log 2>&1
+        user: root
+        state: "{{ 'present' if 'dockhand' in _enabled_services else 'absent' }}"
 
     # ── Ensure DNS CNAME records exist for all enabled services ──────────────
 

--- a/ansible/services/dockhand/update-dockhand
+++ b/ansible/services/dockhand/update-dockhand
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Daily dockhand self-update. Dockhand updates other containers but cannot
+# update itself, so this cron script pulls the floating tag and recreates the
+# container only when the image actually changed. An update sends a Telegram
+# message so silent updates leave a visible trail.
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Same convention as backup.sh: a .disabled marker means deploy-versions has
+# stopped this service — don't pull or restart it.
+if [ -e .disabled ]; then
+    echo "dockhand is disabled; skipping update."
+    exit 0
+fi
+
+IMAGE="fnsys/dockhand:{{ versions.dockhand }}"
+
+{% raw %}
+image_id()      { docker image inspect --format '{{.Id}}' "${IMAGE}" 2>/dev/null || echo "none"; }
+image_version() { docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' "$1" 2>/dev/null || true; }
+{% endraw %}
+short() { case "$1" in sha256:*) echo "${1:7:12}" ;; *) echo "$1" ;; esac; }
+
+before_id=$(image_id)
+before_version=$(image_version "${before_id}")
+
+echo "$(date -Is) pulling ${IMAGE}..."
+docker compose pull --quiet
+docker compose up -d
+
+after_id=$(image_id)
+if [ "${before_id}" = "${after_id}" ]; then
+    echo "dockhand is up to date (${before_version:-$(short "${before_id}")})."
+    exit 0
+fi
+
+after_version=$(image_version "${after_id}")
+old="${before_version:-$(short "${before_id}")}"
+new="${after_version:-$(short "${after_id}")}"
+echo "dockhand updated: ${old} -> ${new}"
+
+# Telegram creds are deployed by configure-system-services.yml (root-only,
+# which is why this cron runs as root). Skip the notification on clusters
+# that don't have monitoring set up yet.
+if [ -r /etc/swintronics/monitoring.env ]; then
+    # shellcheck disable=SC1091
+    source /etc/swintronics/monitoring.env
+    curl -s -X POST \
+        --max-time 10 \
+        --retry 2 \
+        "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -d "chat_id=${TELEGRAM_CHAT_ID}" \
+        --data-urlencode "text=⬆️ $(hostname -s): dockhand updated ${old} → ${new}" >/dev/null || \
+        echo "warning: Telegram notify failed"
+fi

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -28,8 +28,10 @@ versions:
   # https://github.com/henrygd/beszel/releases — pinned (pre-1.0)
   beszel: "0.18.7"
 
-  # https://hub.docker.com/r/fnsys/dockhand/tags — pinned (small project)
-  dockhand: "v1.0.34"
+  # https://hub.docker.com/r/fnsys/dockhand/tags — "latest": dockhand updates
+  # other containers but not itself, so a daily root cron (update-dockhand,
+  # installed by deploy-versions) pulls and recreates it when the image changes.
+  dockhand: "latest"
 
   # https://hub.docker.com/r/willfarrell/autoheal — pinned (rarely updated)
   autoheal: "1.2.0"


### PR DESCRIPTION
## Summary
- Switch dockhand's image tag from pinned `v1.0.34` to `latest` in `versions.yml`
- New `ansible/services/dockhand/update-dockhand` script (deployed like the backup hooks): pulls the floating tag, `docker compose up -d` recreates the container only when the image digest changed, and a real update sends a Telegram message with old → new versions (OCI version label, falling back to short digest)
- `deploy-versions.yml` installs a root cron at 05:00 daily (after the 02:00 immich dump, 03:00 reboot window, and 04:00 backup); the cron is removed when dockhand is disabled or dropped from `versions.yml`, and the script also honors the `.disabled` marker

## Why
Dockhand updates other containers but cannot update itself (#62). The Telegram notification keeps a visible trail of otherwise-silent updates, and Gatus remains the safety net if an update breaks the container. Note dockhand has no tracked `upstream.yml` (its compose was written from scratch), so no upstream-diff discipline is lost by floating the tag.

## Test plan
- [x] `ansible-playbook playbooks/deploy-versions.yml --syntax-check`
- [x] Rendered the script template locally; `bash -n` and shellcheck clean (`{% raw %}` guards keep `docker inspect` format strings intact)
- [ ] `/deploy-and-verify dockhand` — first deploy restarts dockhand once (tag change), then verify `sudo crontab -l` shows the 05:00 entry and run the script once by hand to check the up-to-date path

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)