### PR TITLE
Remove redundant timestamp tag from restic backup hooks

### DIFF
--- a/ansible/services/backup/backup.sh
+++ b/ansible/services/backup/backup.sh
@@ -23,7 +23,7 @@ DOCKER_SERVICES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
-export DATE DAY DATA_MOUNTPOINT
+export DAY DATA_MOUNTPOINT
 DATE=$(date +%F_%H-%M)
 DAY=$(date +%A)
 DATA_MOUNTPOINT="${DATA_MOUNTPOINT:-/mnt/docker-data}"

--- a/ansible/services/homeassistant/backup-remote
+++ b/ansible/services/homeassistant/backup-remote
@@ -20,7 +20,7 @@ push_gatus() {
 trap 'push_gatus false' ERR
 
 echo "Uploading homeassistant snapshots to restic..."
-sudo -E restic backup --retry-lock 10m --tag homeassistant --tag "${DATE:-$(date +%F_%H-%M)}" "${HA_SNAP}" "${Z2M_SNAP}"
+sudo -E restic backup --retry-lock 10m --tag homeassistant "${HA_SNAP}" "${Z2M_SNAP}"
 sudo -E restic forget --retry-lock 10m --tag homeassistant --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
 sudo -E restic check --retry-lock 10m
 

--- a/ansible/services/immich-app/backup-remote
+++ b/ansible/services/immich-app/backup-remote
@@ -18,7 +18,7 @@ push_gatus() {
 trap 'push_gatus false' ERR
 
 echo "Uploading immich snapshot to restic..."
-sudo -E restic backup --retry-lock 10m --tag immich --tag "${DATE:-$(date +%F_%H-%M)}" "${SNAP_DIR}"
+sudo -E restic backup --retry-lock 10m --tag immich "${SNAP_DIR}"
 sudo -E restic forget --retry-lock 10m --tag immich --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
 sudo -E restic check --retry-lock 10m
 

--- a/ansible/services/paperless/backup-remote
+++ b/ansible/services/paperless/backup-remote
@@ -16,7 +16,7 @@ push_gatus() {
 trap 'push_gatus false' ERR
 
 echo "Uploading paperless export to restic..."
-sudo -E restic backup --retry-lock 10m --tag paperless --tag "${DATE:-$(date +%F_%H-%M)}" "${EXPORT_PATH}"
+sudo -E restic backup --retry-lock 10m --tag paperless "${EXPORT_PATH}"
 sudo -E restic forget --retry-lock 10m --tag paperless --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
 sudo -E restic check --retry-lock 10m
 


### PR DESCRIPTION
## Summary
- Drop the per-run `--tag "${DATE:-...}"` from the `restic backup` invocations in the immich-app, paperless, and homeassistant `backup-remote` hooks; the per-service tag (which retention and `delete-backups.yml` key on) is unchanged
- Stop exporting `DATE` from `backup.sh` — no hook consumes it anymore; it stays a local variable for the cron log filename

## Why
The timestamp tag duplicated restic's native snapshot creation time, could never be usefully filtered on (restic tag filters are exact-match only), and was a latent retention footgun: unique per-run tag sets would put every snapshot in its own group if `--group-by tags` were ever added to `forget`. See #106 for the full rationale.

The `server-scripts/backup-*.sh` files also mentioned in the issue were already deleted in #108 — nothing left to clean up there.

Existing snapshots keep their old timestamp tags; that's harmless.

## Test plan
- [ ] `bash -n` passes on all four edited scripts (verified locally)
- [ ] After merge: `/deploy-and-verify`, then run a one-shot backup and confirm the new snapshot carries only the service tag (`restic snapshots --latest 1`)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)