### PR TITLE
Fix duplicate pre-reboot Telegram notices from PathExists retrigger

### DIFF
--- a/ansible/playbooks/configure-system-services.yml
+++ b/ansible/playbooks/configure-system-services.yml
@@ -125,6 +125,14 @@
           # Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
           set -euo pipefail
 
+          # The path unit uses PathExists=/run/reboot-required, which re-triggers
+          # this oneshot for as long as the flag exists. Guard with a per-boot
+          # stamp so the notice is sent only once. /run is tmpfs, so the stamp
+          # clears on reboot and the next update cycle re-arms cleanly.
+          STAMP=/run/swintronics-reboot-notified
+          [[ -e "$STAMP" ]] && exit 0
+          touch "$STAMP"
+
           PKGS="unknown"
           if [[ -s /run/reboot-required.pkgs ]]; then
               PKGS=$(sort -u /run/reboot-required.pkgs | tr '\n' ' ')


### PR DESCRIPTION
## Problem

Each pending-reboot advance notice arrived as **five identical Telegram messages** in rapid succession.

## Root cause

The `swintronics-reboot-scheduled.path` unit uses `PathExists=/run/reboot-required`. Unlike `PathModified=`/`PathChanged=` (which fire on an event), `PathExists=` fires on a *state* and keeps re-activating its associated unit for as long as the flag exists and the unit is inactive. The paired `Type=oneshot` service sent the Telegram notice and exited immediately — so systemd re-triggered it repeatedly. It stopped at exactly five because of systemd's default `StartLimitBurst=5` within `StartLimitIntervalSec=10s`.

## Fix

Guard the send with a per-boot stamp file in `/run` (tmpfs): an early `exit 0` on subsequent activations makes them no-ops, collapsing the loop to a single notice per boot. The stamp clears on reboot, so the next update cycle re-arms cleanly.

## Verification

- Deployed via `ansible-playbook playbooks/configure-system-services.yml` (`ok=25 changed=2 failed=0`).
- Confirmed the stamp guard is present in the deployed `/usr/local/sbin/swintronics-reboot-scheduled.sh` on `xps13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)