### PR TITLE
Remove obsolete Home Assistant http config block

### DIFF
--- a/ansible/services/homeassistant/compose.yml.j2
+++ b/ansible/services/homeassistant/compose.yml.j2
@@ -1,13 +1,4 @@
 # Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
-#
-# NOTE: After first start, add the following to /config/configuration.yaml to
-# trust Traefik's X-Forwarded-For headers (avoids "Your system is potentially
-# exposed to the Internet" warning):
-#
-#   http:
-#     use_x_forwarded_for: true
-#     trusted_proxies:
-#       - 172.16.0.0/12
 
 include:
   - ../networks.yml

--- a/ansible/services/homeassistant/configuration.yaml.j2
+++ b/ansible/services/homeassistant/configuration.yaml.j2
@@ -4,11 +4,9 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    - 172.16.0.0/12   # Docker bridge networks (covers 172.16–172.31)
-    - 100.64.0.0/10   # Tailscale
+# NOTE: reverse-proxy trust (use_x_forwarded_for / trusted_proxies) is no longer
+# configured here. Home Assistant imported the old `http:` block into the UI and
+# now ignores it in YAML — see Settings > System > Network.
 
 # Load frontend themes from the themes folder
 frontend:


### PR DESCRIPTION
## Summary

- Remove the `http:` block (`use_x_forwarded_for` / `trusted_proxies`) from `ansible/services/homeassistant/configuration.yaml.j2`, replacing it with a comment pointing at the UI so it doesn't get re-added.
- Drop the stale NOTE header in `ansible/services/homeassistant/compose.yml.j2` that instructed hand-adding that same `http:` block to `/config/configuration.yaml` after first start.

## Why

Per the [HTTP integration docs](https://www.home-assistant.io/integrations/http/), Home Assistant imports an existing `http:` block into the UI (Settings > System > Network) the first time it starts after upgrade, then **ignores the YAML** and raises a repair issue until the block is removed. Keeping it is dead config plus a permanent repair notification.

The compose NOTE described the exact same obsolete setting — and was doubly stale, since the config had already moved into `configuration.yaml.j2`. Left in place it would tell a future reader to re-add what this PR deletes.

## Verification

`ansible-playbook playbooks/deploy-versions.yml --check --diff --limit xps13` renders exactly the two intended changes and restarts only `homeassistant` — no drift elsewhere:

```
--- before: /docker-data/volumes/homeassistant/configuration.yaml
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    - 172.16.0.0/12   # Docker bridge networks (covers 172.16-172.31)
-    - 100.64.0.0/10   # Tailscale
+# NOTE: reverse-proxy trust (use_x_forwarded_for / trusted_proxies) is no longer
+# configured here. ...
```

## Test plan

- [x] **Before deploying**, confirm Settings > System > Network lists both trusted proxies (`172.16.0.0/12` and `100.64.0.0/10`). If the import didn't take, re-add them in the UI first — otherwise removing the YAML drops the Tailscale range.
- [x] `/deploy-and-verify homeassistant`
- [x] Load HA through Traefik; confirm no "Your system is potentially exposed to the Internet" warning and no lingering repair issue about HTTP YAML config.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbVjpsMzoQVBy2pW4SANdm