### PR TITLE
Add Seafile CE 13 with SeaDoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,7 @@ All runtime secrets are stored in **Infisical** (project: "Swintronics Runtime",
 | beszel         | beszel         | services/beszel/compose.yml.j2        |
 | dockhand       | dockhand       | services/dockhand/compose.yml.j2      |
 | gatus          | gatus          | services/gatus/compose.yml.j2         |
+| seafile        | seafile        | services/seafile/compose.yml.j2       |
 
 ### Adding and Deleting Services
 
@@ -522,4 +523,6 @@ This scenario requires additional planning around Restic repo sharing and is def
 - Long-term: phone-friendly server management — expose remaining service UIs, document mobile access patterns
 
 ### Upstream Compose File Convention
-Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich, paperless, beszel. Not tracked: networking/traefik (fully custom), dockhand (single-container, written from scratch)
+Services adapted from upstream compose files keep a reference copy at `ansible/services/<service>/upstream.yml`. Diff with `diff ansible/services/<service>/upstream.yml ansible/services/<service>/compose.yml.j2` to see local changes. Currently tracked: immich, paperless, beszel, seafile. Not tracked: networking/traefik (fully custom), dockhand (single-container, written from scratch)
+
+Seafile's `upstream.yml` is a concatenation of upstream's `seafile-server.yml` and `seadoc.yml`; `caddy.yml` is intentionally omitted since Traefik handles TLS.

--- a/ansible/inventory/host_vars/xps13.yml
+++ b/ansible/inventory/host_vars/xps13.yml
@@ -15,7 +15,7 @@ zigbee_dongle_path: /dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plu
 
 # Seafile superuser, created on first startup only. The password is generated
 # by Terraform and stored in Infisical as SEAFILE_ADMIN_PASSWORD.
-seafile_admin_email: "neil25@swintonhome.com"
+seafile_admin_email: "neil@swintronics.com"
 
 git_user_name: "Neil Swinton"
 git_user_email: "5995552+neilswinton@users.noreply.github.com"

--- a/ansible/inventory/host_vars/xps13.yml
+++ b/ansible/inventory/host_vars/xps13.yml
@@ -13,5 +13,9 @@ hardware_watchdog_module: "iTCO_wdt"
 # Find with: ls /dev/serial/by-id/   (ZBDongle-P plugged in)
 zigbee_dongle_path: /dev/serial/by-id/usb-ITead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_eecce27957a4ef11abc3a78086a24396-if00-port0
 
+# Seafile superuser, created on first startup only. The password is generated
+# by Terraform and stored in Infisical as SEAFILE_ADMIN_PASSWORD.
+seafile_admin_email: "neil25@swintonhome.com"
+
 git_user_name: "Neil Swinton"
 git_user_email: "5995552+neilswinton@users.noreply.github.com"

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -105,6 +105,14 @@
         files:
           - { src: compose.yml.j2,    dest: compose.yml }
           - { src: mosquitto.conf.j2, dest: mosquitto.conf }
+      # SeaDoc ships inside this stack; versions.seadoc supplies its tag but it
+      # is deliberately not a _service_config key of its own.
+      seafile:
+        dir: seafile
+        dns_names: [seafile]
+        files:
+          - { src: compose.yml.j2,  dest: compose.yml }
+          - { src: .env.j2,         dest: .env,               secret: true }
 
   pre_tasks:
     - name: Determine disabled services

--- a/ansible/playbooks/setup-storage.yml
+++ b/ansible/playbooks/setup-storage.yml
@@ -35,6 +35,7 @@
       homeassistant: { dir: homeassistant,  stateful: true  }
       zigbee2mqtt:   { dir: zigbee2mqtt,    stateful: true  }
       mosquitto:     { dir: mosquitto,      stateful: true  }
+      seafile:       { dir: seafile,        stateful: true  }
 
   pre_tasks:
     - name: Load versions

--- a/ansible/services/gatus/config.yaml.j2
+++ b/ansible/services/gatus/config.yaml.j2
@@ -38,6 +38,14 @@ endpoints:
     conditions: ["[STATUS] == 200"]
     alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
 
+  - name: Seafile
+    enabled: {{ ('seafile' not in disabled_services | default([])) | lower }}
+    group: Services
+    url: https://seafile.{{ server_domain }}/accounts/login/
+    interval: 5m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{type: telegram, failure-threshold: 3, success-threshold: 1, send-on-resolved: true}]
+
   - name: Home Assistant
     enabled: {{ ('homeassistant' not in disabled_services | default([])) | lower }}
     group: Services

--- a/ansible/services/seafile/.env.j2
+++ b/ansible/services/seafile/.env.j2
@@ -1,0 +1,19 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+
+TZ={{ timezone }}
+CERT_RESOLVER={{ cert_resolver }}
+
+# Admin account — only consumed on first startup, when Seafile creates the
+# initial superuser. Changing these later has no effect; use the Seahub UI.
+SEAFILE_ADMIN_EMAIL={{ seafile_admin_email }}
+SEAFILE_ADMIN_PASSWORD={{ infisical_secrets.secrets.SEAFILE_ADMIN_PASSWORD }}
+
+# Database. The root password is only used on first startup to create the
+# seafile user and the ccnet/seafile/seahub databases.
+SEAFILE_MYSQL_ROOT_PASSWORD={{ infisical_secrets.secrets.SEAFILE_MYSQL_ROOT_PASSWORD }}
+SEAFILE_MYSQL_DB_PASSWORD={{ infisical_secrets.secrets.SEAFILE_MYSQL_DB_PASSWORD }}
+
+SEAFILE_REDIS_PASSWORD={{ infisical_secrets.secrets.SEAFILE_REDIS_PASSWORD }}
+
+# Shared by seafile and seadoc to sign inter-service tokens — both must match.
+SEAFILE_JWT_PRIVATE_KEY={{ infisical_secrets.secrets.SEAFILE_JWT_PRIVATE_KEY }}

--- a/ansible/services/seafile/compose.yml.j2
+++ b/ansible/services/seafile/compose.yml.j2
@@ -1,0 +1,137 @@
+# Managed by Ansible. Do not edit — changes will be overwritten on next deployment.
+#
+# Adapted from upstream.yml (Seafile CE 13 seafile-server.yml + seadoc.yml).
+# Local changes:
+#   - caddy.yml and the caddy labels are dropped; Traefik terminates TLS
+#   - db/redis renamed to seafile-db/seafile-redis: every stack shares the
+#     external `proxy` network and paperless already publishes a `db` alias
+#   - container_name overrides dropped so compose namespaces them
+#   - SEAFILE_SERVER_PROTOCOL=https so Seahub generates https:// links
+#   - file data bind-mounted to the btrfs data disk; MariaDB in a named volume
+
+name: seafile
+include:
+  - ../networks.yml
+
+services:
+  seafile-db:
+    image: mariadb:10.11
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SEAFILE_MYSQL_ROOT_PASSWORD:?Variable is not set or empty}
+      - MYSQL_LOG_CONSOLE=true
+      - MARIADB_AUTO_UPGRADE=1
+    volumes:
+      - dbdata:/var/lib/mysql
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/usr/local/bin/healthcheck.sh",
+          "--connect",
+          "--mariadbupgrade",
+          "--innodb_initialized",
+        ]
+      interval: 20s
+      start_period: 30s
+      timeout: 5s
+      retries: 10
+
+  seafile-redis:
+    image: redis:8-alpine
+    restart: always
+    command:
+      - /bin/sh
+      - -c
+      - exec redis-server --requirepass "$$REDIS_PASSWORD" --save "" --appendonly no
+    environment:
+      - REDIS_PASSWORD=${SEAFILE_REDIS_PASSWORD:?Variable is not set or empty}
+
+  seafile:
+    image: seafileltd/seafile-mc:{{ versions.seafile }}
+    restart: always
+    volumes:
+      - {{ data_disk_mountpoint }}/volumes/seafile/data:/shared
+    environment:
+      - SEAFILE_MYSQL_DB_HOST=seafile-db
+      - SEAFILE_MYSQL_DB_PORT=3306
+      - SEAFILE_MYSQL_DB_USER=seafile
+      - SEAFILE_MYSQL_DB_PASSWORD=${SEAFILE_MYSQL_DB_PASSWORD:?Variable is not set or empty}
+      - INIT_SEAFILE_MYSQL_ROOT_PASSWORD=${SEAFILE_MYSQL_ROOT_PASSWORD:?Variable is not set or empty}
+      - SEAFILE_MYSQL_DB_CCNET_DB_NAME=ccnet_db
+      - SEAFILE_MYSQL_DB_SEAFILE_DB_NAME=seafile_db
+      - SEAFILE_MYSQL_DB_SEAHUB_DB_NAME=seahub_db
+      - TIME_ZONE=${TZ:-Etc/UTC}
+      - INIT_SEAFILE_ADMIN_EMAIL=${SEAFILE_ADMIN_EMAIL:?Variable is not set or empty}
+      - INIT_SEAFILE_ADMIN_PASSWORD=${SEAFILE_ADMIN_PASSWORD:?Variable is not set or empty}
+      - SEAFILE_SERVER_HOSTNAME={{ _service_config.seafile.dns_names[0] }}.{{ server_domain }}
+      - SEAFILE_SERVER_PROTOCOL=https
+      - SITE_ROOT=/
+      - NON_ROOT=false
+      - JWT_PRIVATE_KEY=${SEAFILE_JWT_PRIVATE_KEY:?Variable is not set or empty}
+      - SEAFILE_LOG_TO_STDOUT=false
+      - ENABLE_GO_FILESERVER=true
+      - ENABLE_SEADOC=true
+      - SEADOC_SERVER_URL=https://{{ _service_config.seafile.dns_names[0] }}.{{ server_domain }}/sdoc-server
+      - CACHE_PROVIDER=redis
+      - REDIS_HOST=seafile-redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${SEAFILE_REDIS_PASSWORD:?Variable is not set or empty}
+      - ENABLE_NOTIFICATION_SERVER=false
+      - ENABLE_SEAFILE_AI=false
+      - ENABLE_FACE_RECOGNITION=false
+      - MD_FILE_COUNT_LIMIT=100000
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    depends_on:
+      seafile-db:
+        condition: service_healthy
+      seafile-redis:
+        condition: service_started
+    labels:
+      traefik.enable: true
+      traefik.http.routers.seafile.entrypoints: websecure
+      traefik.http.routers.seafile.rule: Host(`{{ _service_config.seafile.dns_names[0] }}.{{ server_domain }}`)
+      traefik.http.routers.seafile.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.services.seafile.loadbalancer.server.port: 80
+
+  seadoc:
+    image: seafileltd/sdoc-server:{{ versions.seadoc }}
+    restart: always
+    volumes:
+      - {{ data_disk_mountpoint }}/volumes/seafile/seadoc:/shared
+    environment:
+      - DB_HOST=seafile-db
+      - DB_PORT=3306
+      - DB_USER=seafile
+      - DB_PASSWORD=${SEAFILE_MYSQL_DB_PASSWORD:?Variable is not set or empty}
+      - DB_NAME=seahub_db
+      - TIME_ZONE=${TZ:-Etc/UTC}
+      - JWT_PRIVATE_KEY=${SEAFILE_JWT_PRIVATE_KEY:?Variable is not set or empty}
+      - NON_ROOT=false
+      - SEAHUB_SERVICE_URL=http://seafile
+    depends_on:
+      seafile-db:
+        condition: service_healthy
+    # Upstream proxies these two paths to seadoc:80 via caddy `handle_path`:
+    # /sdoc-server has its prefix stripped, /socket.io keeps it. Traefik sorts
+    # routers by rule specificity, so both win over the plain Host() router.
+    labels:
+      traefik.enable: true
+      traefik.http.routers.seadoc.entrypoints: websecure
+      traefik.http.routers.seadoc.rule: Host(`{{ _service_config.seafile.dns_names[0] }}.{{ server_domain }}`) && PathPrefix(`/sdoc-server`)
+      traefik.http.routers.seadoc.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.routers.seadoc.middlewares: seadoc-strip
+      traefik.http.middlewares.seadoc-strip.stripprefix.prefixes: /sdoc-server
+      traefik.http.routers.seadoc-socketio.entrypoints: websecure
+      traefik.http.routers.seadoc-socketio.rule: Host(`{{ _service_config.seafile.dns_names[0] }}.{{ server_domain }}`) && PathPrefix(`/socket.io`)
+      traefik.http.routers.seadoc-socketio.tls.certresolver: ${CERT_RESOLVER}
+      traefik.http.routers.seadoc-socketio.service: seadoc
+      traefik.http.services.seadoc.loadbalancer.server.port: 80
+
+volumes:
+  dbdata:

--- a/ansible/services/seafile/upstream.yml
+++ b/ansible/services/seafile/upstream.yml
@@ -1,0 +1,142 @@
+# Upstream reference copy — Seafile CE 13.0.
+# Sources (concatenated verbatim; the `networks:` block of seadoc.yml is
+# dropped as a duplicate):
+#   https://manual.seafile.com/13.0/repo/docker/ce/seafile-server.yml
+#   https://manual.seafile.com/13.0/repo/docker/seadoc.yml
+# Diff against compose.yml.j2 to see local changes. Do not deploy this file.
+
+services:
+  db:
+    image: ${SEAFILE_DB_IMAGE:-mariadb:10.11}
+    container_name: seafile-mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=${INIT_SEAFILE_MYSQL_ROOT_PASSWORD:-}
+      - MYSQL_LOG_CONSOLE=true
+      - MARIADB_AUTO_UPGRADE=1
+    volumes:
+      - "${SEAFILE_MYSQL_VOLUME:-/opt/seafile-mysql/db}:/var/lib/mysql"
+    networks:
+      - seafile-net
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/usr/local/bin/healthcheck.sh",
+          "--connect",
+          "--mariadbupgrade",
+          "--innodb_initialized",
+        ]
+      interval: 20s
+      start_period: 30s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: ${SEAFILE_REDIS_IMAGE:-redis}
+    container_name: seafile-redis
+    restart: unless-stopped
+    command:
+      - /bin/sh
+      - -c
+      - exec redis-server --requirepass "$$REDIS_PASSWORD" --save "" --appendonly no
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    networks:
+      - seafile-net
+
+  seafile:
+    image: ${SEAFILE_IMAGE:-seafileltd/seafile-mc:13.0-latest}
+    container_name: seafile
+    restart: unless-stopped
+    # ports:
+    #   - "80:80"
+    volumes:
+      - ${SEAFILE_VOLUME:-/opt/seafile-data}:/shared
+    environment:
+      - SEAFILE_MYSQL_DB_HOST=${SEAFILE_MYSQL_DB_HOST:-db}
+      - SEAFILE_MYSQL_DB_PORT=${SEAFILE_MYSQL_DB_PORT:-3306}
+      - SEAFILE_MYSQL_DB_USER=${SEAFILE_MYSQL_DB_USER:-seafile}
+      - SEAFILE_MYSQL_DB_PASSWORD=${SEAFILE_MYSQL_DB_PASSWORD:?Variable is not set or empty}
+      - INIT_SEAFILE_MYSQL_ROOT_PASSWORD=${INIT_SEAFILE_MYSQL_ROOT_PASSWORD:-}
+      - SEAFILE_MYSQL_DB_CCNET_DB_NAME=${SEAFILE_MYSQL_DB_CCNET_DB_NAME:-ccnet_db}
+      - SEAFILE_MYSQL_DB_SEAFILE_DB_NAME=${SEAFILE_MYSQL_DB_SEAFILE_DB_NAME:-seafile_db}
+      - SEAFILE_MYSQL_DB_SEAHUB_DB_NAME=${SEAFILE_MYSQL_DB_SEAHUB_DB_NAME:-seahub_db}
+      - TIME_ZONE=${TIME_ZONE:-Etc/UTC}
+      - INIT_SEAFILE_ADMIN_EMAIL=${INIT_SEAFILE_ADMIN_EMAIL:-me@example.com}
+      - INIT_SEAFILE_ADMIN_PASSWORD=${INIT_SEAFILE_ADMIN_PASSWORD:-asecret}
+      - SEAFILE_SERVER_HOSTNAME=${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
+      - SEAFILE_SERVER_PROTOCOL=${SEAFILE_SERVER_PROTOCOL:-http}
+      - SITE_ROOT=${SITE_ROOT:-/}
+      - NON_ROOT=${NON_ROOT:-false}
+      - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?Variable is not set or empty}
+      - SEAFILE_LOG_TO_STDOUT=${SEAFILE_LOG_TO_STDOUT:-false}
+      - ENABLE_GO_FILESERVER=${ENABLE_GO_FILESERVER:-true}
+      - ENABLE_SEADOC=${ENABLE_SEADOC:-true}
+      - SEADOC_SERVER_URL=${SEAFILE_SERVER_PROTOCOL:-http}://${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}/sdoc-server
+      - CACHE_PROVIDER=${CACHE_PROVIDER:-redis}
+      - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_PORT=${REDIS_PORT:-6379}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+      - MEMCACHED_HOST=${MEMCACHED_HOST:-memcached}
+      - MEMCACHED_PORT=${MEMCACHED_PORT:-11211}
+      - ENABLE_NOTIFICATION_SERVER=${ENABLE_NOTIFICATION_SERVER:-false}
+      - INNER_NOTIFICATION_SERVER_URL=${INNER_NOTIFICATION_SERVER_URL:-http://notification-server:8083}
+      - NOTIFICATION_SERVER_URL=${NOTIFICATION_SERVER_URL:-${SEAFILE_SERVER_PROTOCOL:-http}://${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}/notification}
+      - ENABLE_SEAFILE_AI=${ENABLE_SEAFILE_AI:-false}
+      - ENABLE_FACE_RECOGNITION=${ENABLE_FACE_RECOGNITION:-false}
+      - SEAFILE_AI_SERVER_URL=${SEAFILE_AI_SERVER_URL:-http://seafile-ai:8888}
+      - SEAFILE_AI_SECRET_KEY=${JWT_PRIVATE_KEY:?Variable is not set or empty}
+      - MD_FILE_COUNT_LIMIT=${MD_FILE_COUNT_LIMIT:-100000}
+    labels:
+      caddy: ${SEAFILE_SERVER_PROTOCOL:-http}://${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
+      caddy.reverse_proxy: "{{upstreams 80}}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - seafile-net
+
+  seadoc:
+    image: ${SEADOC_IMAGE:-seafileltd/sdoc-server:2.0-latest}
+    container_name: seadoc
+    restart: unless-stopped
+    volumes:
+      - ${SEADOC_VOLUME:-/opt/seadoc-data/}:/shared
+    # ports:
+    #   - "80:80"
+    environment:
+      - DB_HOST=${SEAFILE_MYSQL_DB_HOST:-db}
+      - DB_PORT=${SEAFILE_MYSQL_DB_PORT:-3306}
+      - DB_USER=${SEAFILE_MYSQL_DB_USER:-seafile}
+      - DB_PASSWORD=${SEAFILE_MYSQL_DB_PASSWORD:?Variable is not set or empty}
+      - DB_NAME=${SEADOC_MYSQL_DB_NAME:-${SEAFILE_MYSQL_DB_SEAHUB_DB_NAME:-seahub_db}}
+      - TIME_ZONE=${TIME_ZONE:-Etc/UTC}
+      - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY:?Variable is not set or empty}
+      - NON_ROOT=${NON_ROOT:-false}
+      - SEAHUB_SERVICE_URL=${SEAHUB_SERVICE_URL:-http://seafile}
+    labels:
+      caddy: ${SEAFILE_SERVER_PROTOCOL:-http}://${SEAFILE_SERVER_HOSTNAME:?Variable is not set or empty}
+      caddy.1_handle_path: "/socket.io/*"
+      caddy.1_handle_path.0_rewrite: "* /socket.io{uri}"
+      caddy.1_handle_path.1_reverse_proxy: "{{upstreams 80}}"
+      caddy.2_handle_path: "/sdoc-server/*"
+      caddy.2_handle_path.0_rewrite: "* {uri}"
+      caddy.2_handle_path.1_reverse_proxy: "{{upstreams 80}}"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - seafile-net
+
+networks:
+  seafile-net:
+    name: seafile-net

--- a/ansible/versions.yml
+++ b/ansible/versions.yml
@@ -48,6 +48,14 @@ versions:
   # https://hub.docker.com/_/mosquitto — floating major (extremely stable)
   mosquitto: "2"
 
+  # https://manual.seafile.com/13.0/ — floating patch within 13.0. Major
+  # upgrades need a database migration; bump the major deliberately.
+  seafile: "13.0-latest"
+
+  # https://hub.docker.com/r/seafileltd/sdoc-server/tags — SeaDoc collaborative
+  # editor. Ships inside the seafile stack, not a service of its own.
+  seadoc: "2.0-latest"
+
 # Services listed here are stopped by deploy-versions (`docker compose down`)
 # while their compose files, config, volumes, and Docker network are left
 # intact. Remove a name to re-enable — the next deploy redeploys and restarts

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -172,6 +172,54 @@ resource "random_password" "z2m_frontend_auth_token" {
   }
 }
 
+# Seafile — all alphanumeric (special = false): these values are read back
+# through a compose `.env` file, where `$` and quotes are a foot-gun.
+resource "random_password" "seafile_mysql_root_password" {
+  length  = 24
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special, min_lower, min_upper, min_numeric, min_special, keepers]
+  }
+}
+
+resource "random_password" "seafile_mysql_db_password" {
+  length  = 24
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special, min_lower, min_upper, min_numeric, min_special, keepers]
+  }
+}
+
+# Seafile requires a JWT key of at least 32 characters.
+resource "random_password" "seafile_jwt_private_key" {
+  length  = 48
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special, min_lower, min_upper, min_numeric, min_special, keepers]
+  }
+}
+
+resource "random_password" "seafile_redis_password" {
+  length  = 32
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special, min_lower, min_upper, min_numeric, min_special, keepers]
+  }
+}
+
+resource "random_password" "seafile_admin_password" {
+  length  = 24
+  special = false
+
+  lifecycle {
+    ignore_changes = [length, special, override_special, min_lower, min_upper, min_numeric, min_special, keepers]
+  }
+}
+
 resource "random_uuid" "gatus_backup_push_token" {}
 
 # Immich
@@ -205,6 +253,49 @@ resource "infisical_secret" "dockhand_encryption_key" {
 resource "infisical_secret" "z2m_frontend_auth_token" {
   name         = "Z2M_FRONTEND_AUTH_TOKEN"
   value        = random_password.z2m_frontend_auth_token.result
+  env_slug     = "dev"
+  workspace_id = infisical_project.runtime_secrets.id
+  folder_path  = "/"
+}
+
+# Seafile
+# INIT_* values are only consumed on first startup; they are kept here so a
+# re-pave reproduces the same admin login and database credentials.
+resource "infisical_secret" "seafile_mysql_root_password" {
+  name         = "SEAFILE_MYSQL_ROOT_PASSWORD"
+  value        = random_password.seafile_mysql_root_password.result
+  env_slug     = "dev"
+  workspace_id = infisical_project.runtime_secrets.id
+  folder_path  = "/"
+}
+
+resource "infisical_secret" "seafile_mysql_db_password" {
+  name         = "SEAFILE_MYSQL_DB_PASSWORD"
+  value        = random_password.seafile_mysql_db_password.result
+  env_slug     = "dev"
+  workspace_id = infisical_project.runtime_secrets.id
+  folder_path  = "/"
+}
+
+resource "infisical_secret" "seafile_jwt_private_key" {
+  name         = "SEAFILE_JWT_PRIVATE_KEY"
+  value        = random_password.seafile_jwt_private_key.result
+  env_slug     = "dev"
+  workspace_id = infisical_project.runtime_secrets.id
+  folder_path  = "/"
+}
+
+resource "infisical_secret" "seafile_redis_password" {
+  name         = "SEAFILE_REDIS_PASSWORD"
+  value        = random_password.seafile_redis_password.result
+  env_slug     = "dev"
+  workspace_id = infisical_project.runtime_secrets.id
+  folder_path  = "/"
+}
+
+resource "infisical_secret" "seafile_admin_password" {
+  name         = "SEAFILE_ADMIN_PASSWORD"
+  value        = random_password.seafile_admin_password.result
   env_slug     = "dev"
   workspace_id = infisical_project.runtime_secrets.id
   folder_path  = "/"


### PR DESCRIPTION
Adds Seafile (self-hosted file sync & share) as a first-class service, deployed through `deploy-versions.yml` like everything else. SeaDoc collaborative editing is enabled.

**No backup hooks in this pass** — this is a trial. Storage still lands on the btrfs data disk, so hooks can be added later without moving data.

## Upstream adaptation

Upstream's `seafile-server.yml` + `seadoc.yml` are kept verbatim in `ansible/services/seafile/upstream.yml` for diffing. Local changes:

| Upstream | Here | Why |
|---|---|---|
| `caddy.yml` + `caddy:` labels | dropped, Traefik labels | Traefik already terminates TLS |
| services `db`, `redis` | `seafile-db`, `seafile-redis` | all stacks share the external `proxy` network, and `paperless-db-1` already publishes a bare `db` alias there — verified with `docker inspect` |
| `SEAFILE_SERVER_PROTOCOL=http` | `https` | Seahub must generate `https://` links behind Traefik |
| `container_name:` overrides | removed | matches paperless/immich |
| `/opt/seafile-data` | `{{ data_disk_mountpoint }}/volumes/seafile/data` | file data belongs on the 369 GB btrfs disk; root has 38 GB free |
| MariaDB on a bind mount | named volume `dbdata` | matches paperless; avoids btrfs CoW on InnoDB |
| healthcheck `start_period: 10s` | `120s` | first boot initialises three databases and would otherwise flap unhealthy |

SeaDoc needs the *external* proxy to route two paths to `seadoc:80` — the seafile container does not proxy them. `/sdoc-server` has its prefix stripped (`stripprefix` middleware), `/socket.io` keeps it and upgrades to a websocket. Traefik sorts routers by rule specificity, so both beat the plain `Host()` router without explicit priorities.

## Deploy order

`terraform apply` **must** run first — it generates the five Infisical secrets. Without them `.env` renders empty and the containers exit on `Variable is not set or empty`.

```
cd terraform && terraform apply
cd ansible && source .env && ansible-playbook playbooks/setup-storage.yml
# then /deploy-and-verify seafile
```

## Verification done here

- `terraform validate` + `terraform fmt -check` pass
- `ansible-lint --profile=min` passes (production profile too)
- Both templates render under `StrictUndefined`; `docker compose config` parses the result and resolves to the expected images, routers, mounts, and the external `proxy` network

Post-merge verification (server-side) is in the plan: containers healthy, login page over a valid cert, and an `.sdoc` file that opens and accepts typing — that last one exercises both SeaDoc routes.

## Note

The XPS13 has 7.5 GB RAM with ~4.5 GB available and 1.6 GB swap already in use. This stack adds roughly 1.5–1.8 GB. It should fit, but if it gets tight the cheapest lever is `ENABLE_SEADOC=false`, then `disabled_services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x1KDdKM8UA4JEzcg8V5QX