### PR TITLE
Enable Home Assistant packages/ split config

### DIFF
--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -232,6 +232,8 @@
         mode: '0755'
       loop: "{{ _enabled_services }}"
 
+    # Owned by admin_user (not root like the HACS dirs below) so the
+    # ha-claude-project deploy can rsync package YAML straight into it.
     - name: Ensure Home Assistant packages directory exists
       ansible.builtin.file:
         path: "{{ data_disk_mountpoint }}/volumes/homeassistant/packages"

--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -232,6 +232,14 @@
         mode: '0755'
       loop: "{{ _enabled_services }}"
 
+    - name: Ensure Home Assistant packages directory exists
+      ansible.builtin.file:
+        path: "{{ data_disk_mountpoint }}/volumes/homeassistant/packages"
+        state: directory
+        owner: "{{ admin_user }}"
+        mode: '0755'
+      when: "'homeassistant' in _enabled_services"
+
     - name: Ensure traefik-data directories exist
       ansible.builtin.file:
         path: "{{ docker_services_path }}/networking/{{ item }}"

--- a/ansible/services/homeassistant/configuration.yaml.j2
+++ b/ansible/services/homeassistant/configuration.yaml.j2
@@ -9,8 +9,10 @@ default_config:
 # now ignores it in YAML — see Settings > System > Network.
 
 # Split-config YAML lives in packages/, deployed out of the ha-claude-project
-# repo. The directory is created by the deploy playbook: !include_dir_named on a
-# missing directory is a hard startup failure.
+# repo. The deploy playbook creates the directory owned by admin_user so that
+# repo's rsync has a writable target. A missing directory is not fatal: HA walks
+# these includes with os.walk and yields an empty mapping, so the packages would
+# just be silently absent (themes/ below is referenced but does not exist).
 homeassistant:
   packages: !include_dir_named packages
 

--- a/ansible/services/homeassistant/configuration.yaml.j2
+++ b/ansible/services/homeassistant/configuration.yaml.j2
@@ -8,6 +8,12 @@ default_config:
 # configured here. Home Assistant imported the old `http:` block into the UI and
 # now ignores it in YAML — see Settings > System > Network.
 
+# Split-config YAML lives in packages/, deployed out of the ha-claude-project
+# repo. The directory is created by the deploy playbook: !include_dir_named on a
+# missing directory is a hard startup failure.
+homeassistant:
+  packages: !include_dir_named packages
+
 # Load frontend themes from the themes folder
 frontend:
   themes: !include_dir_merge_named themes


### PR DESCRIPTION
Closes #124

Home Assistant has no `homeassistant: packages:` block, so YAML placed in the config volume's
`packages/` directory is silently inert — no error, no entities. The `ha-claude-project` repo
deploys package YAML there and is blocked on this.

## Changes

- **`configuration.yaml.j2`** — add `homeassistant: packages: !include_dir_named packages`
- **`deploy-versions.yml`** — create `volumes/homeassistant/packages`, owned by `admin_user`
  so the rsync from `ha-claude-project` can write into it

## Why it takes effect

`configuration.yaml.j2` is listed in `_service_config.homeassistant.files`, so a change to it
lands in `_file_results` → `_changed_services` → HA restart. The directory task runs at
`deploy-versions.yml:235`, ahead of *Deploy service files* at `:255`, so the directory exists
before the config referencing it is written.

## Rationale correction (`cd73f2b`)

The first commit claimed `!include_dir_named` against a missing directory is a hard startup
failure. **It isn't.** HA resolves these includes through `_find_files` → `os.walk`, which
yields nothing for a missing path and returns an empty mapping.

Verified against the running XPS13: `configuration.yaml` already contains
`!include_dir_merge_named themes`, the config volume has no `themes/` directory
(only `custom_components`), and the container reports `Up 15 hours` with no config errors.

The directory task stays — rsync needs an existing, correctly-owned target — but that is the
real reason, and the second commit reworks both comments to say so. Comments only, no behavior
change.

## Verification

- `ansible-lint --profile=min` passes on both commits (also clears the stricter *production*
  profile)
- Not yet deployed — needs `/deploy-and-verify` after merge

## Known gaps (tracked in #124, not addressed here)

- `themes/` is referenced but never created by any playbook
- A rebuilt server gets an empty `packages/`; HA starts fine but silently without those entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x1KDdKM8UA4JEzcg8V5QX