### PR TITLE
Own HA include dirs as admin_user:admin_user, create themes/

### DIFF
--- a/ansible/playbooks/deploy-versions.yml
+++ b/ansible/playbooks/deploy-versions.yml
@@ -232,14 +232,20 @@
         mode: '0755'
       loop: "{{ _enabled_services }}"
 
-    # Owned by admin_user (not root like the HACS dirs below) so the
-    # ha-claude-project deploy can rsync package YAML straight into it.
-    - name: Ensure Home Assistant packages directory exists
+    # Both directories are referenced by configuration.yaml. Owned by
+    # admin_user (not root like the HACS dirs below) because ha-claude-project
+    # deploys packages/ with an unprivileged `rsync -a`, which preserves group
+    # as well as owner. HA runs as root in-container and can still write themes/.
+    - name: Ensure Home Assistant config include directories exist
       ansible.builtin.file:
-        path: "{{ data_disk_mountpoint }}/volumes/homeassistant/packages"
+        path: "{{ data_disk_mountpoint }}/volumes/homeassistant/{{ item }}"
         state: directory
         owner: "{{ admin_user }}"
+        group: "{{ admin_user }}"
         mode: '0755'
+      loop:
+        - packages
+        - themes
       when: "'homeassistant' in _enabled_services"
 
     - name: Ensure traefik-data directories exist

--- a/ansible/services/homeassistant/configuration.yaml.j2
+++ b/ansible/services/homeassistant/configuration.yaml.j2
@@ -12,7 +12,7 @@ default_config:
 # repo. The deploy playbook creates the directory owned by admin_user so that
 # repo's rsync has a writable target. A missing directory is not fatal: HA walks
 # these includes with os.walk and yields an empty mapping, so the packages would
-# just be silently absent (themes/ below is referenced but does not exist).
+# just be silently absent. The playbook creates themes/ on the same grounds.
 homeassistant:
   packages: !include_dir_named packages
 


### PR DESCRIPTION
Follow-up to #125 / #124.

## Permissions

`packages/` landed on the XPS13 as `neil:root` — the `file` task set `owner:` but no `group:`,
so the directory kept root's group from creation.

`ha-claude-project`'s `make deploy` is the only write path into that bind mount, and it uses an
unprivileged `rsync -a --delete` running as the admin user. `-a` implies `-g`, so it tries to
preserve group as well as owner. Setting `group:` to `admin_user` makes the target match what
that rsync expects instead of relying on it to quietly not care.

## themes/

`configuration.yaml` has referenced `!include_dir_merge_named themes` all along with no such
directory on disk. That is harmless — a missing include directory yields an empty mapping, as
confirmed when HA restarted clean during the #125 deploy — but HACS installs themes into that
path, and #124 tracked the inconsistency. Both directories are now created by one looped task.

`themes/` gets the same ownership. HA runs as root inside the container, so it can still write
there regardless.

## Verification

- `ansible-lint --profile=min` passes (also clears the stricter *production* profile)
- Not yet deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x1KDdKM8UA4JEzcg8V5QX