### PR TITLE
Cut HA recorder retention to 7 days and right-size HA backup retention

### DIFF
--- a/ansible/services/homeassistant/backup-remote
+++ b/ansible/services/homeassistant/backup-remote
@@ -21,7 +21,7 @@ trap 'push_gatus false' ERR
 
 echo "Uploading homeassistant snapshots to restic..."
 sudo -E restic backup --retry-lock 10m --tag homeassistant "${HA_SNAP}" "${Z2M_SNAP}"
-sudo -E restic forget --retry-lock 10m --tag homeassistant --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
+sudo -E restic forget --retry-lock 10m --tag homeassistant --keep-daily 7 --keep-weekly 2 --keep-monthly 1 --prune
 sudo -E restic check --retry-lock 10m
 
 for pair in "${HA_SNAP}:${HA_ARCHIVE}" "${Z2M_SNAP}:${Z2M_ARCHIVE}"; do

--- a/ansible/services/homeassistant/configuration.yaml.j2
+++ b/ansible/services/homeassistant/configuration.yaml.j2
@@ -4,6 +4,12 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
+# History detail retention. Long-term statistics live in separate tables and are
+# not affected, so the Energy dashboard and the kiln/EV utility meters keep their
+# full history regardless of this value. See issue #127.
+recorder:
+  purge_keep_days: 7
+
 # NOTE: reverse-proxy trust (use_x_forwarded_for / trusted_proxies) is no longer
 # configured here. Home Assistant imported the old `http:` block into the UI and
 # now ignores it in YAML — see Settings > System > Network.


### PR DESCRIPTION
Repo-owned half of #127. The entity-registry half (disabling 112 unused SPAN
entities) is already live on the XPS13 and is what produced the numbers below.

## Why

The HA recorder DB reached 3.6 GiB, 99.4% of state rows coming from the SPAN
panel v2 integration writing one row per sensor every ~5 s across 203 entities.
Purge retention was working correctly — the size was pure write rate. Because a
churning SQLite file dedupes poorly, the DB also dominated the nightly restic
upload.

## Measured effect of the entity disable (already live)

Measured against a copy of the live DB, 5 h after the post-change reboot:

| | before | after |
|---|---|---|
| states rows/day | ~1,730,000 | **~285,000** |
| rows/hour | ~72,000 | 11,891 |
| SPAN entities writing | 203 | **30** |

**83.5% reduction.** The per-day counts show the cliff: 1.73M/day steady through
08-19, 1.52M on the 08-20 changeover day, 108,729 in the first 9.15 h of 08-21.

Note for the record: disabled entities kept writing until a clean restart —
registry-disable alone does not drop them from the state machine mid-run. After
the reboot the disable is fully effective, so no `recorder: exclude:` fallback
is needed.

## What this PR changes

- **`configuration.yaml.j2`** — add `recorder: purge_keep_days: 7` (down from
  the default 10). Long-term statistics live in separate tables and are not
  affected, so the Energy dashboard and the kiln/EV utility meters keep their
  full history.
- **`backup-remote`** — restic retention for the `homeassistant` tag goes from
  `--keep-daily 7 --keep-weekly 4 --keep-monthly 3` to `7/2/1`.

## Constraints respected

- The DB file is still backed up (long-term statistics live inside it).
- No `_energy_consumed` sensor for the kiln, EV charger, HVAC circuits, or the
  panel main meter was disabled or excluded.
- SPAN `snapshot_update_interval` left at the 5 s default — `binary_sensor.span_panel_kiln_running`
  is a threshold sensor and would miss ~5 s kiln element bursts.

## After merge

Deploy via `/deploy-and-verify`, then call `recorder.purge` with `repack: true`
to reclaim the 3.6 GiB immediately (SQLite never returns pages on its own, and
auto-repack only runs the second Sunday). Re-measure at day 8 and close #127.

Refs #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcU6MMW7N9TdCEiskfdaVj